### PR TITLE
Udev event device matching

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -276,7 +276,6 @@ static void wlr_drm_output_enable(struct wlr_output_state *output, bool enable) 
 
 static void wlr_drm_output_destroy(struct wlr_output_state *output) {
 	wlr_drm_output_cleanup(output, true);
-	wlr_drm_renderer_free(output->renderer);
 	free(output);
 }
 

--- a/include/backend/udev.h
+++ b/include/backend/udev.h
@@ -9,7 +9,6 @@
 struct wlr_udev {
 	struct udev *udev;
 	struct udev_monitor *mon;
-	char *drm_path;
 	struct wl_event_source *event;
 	struct wl_signal invalidate_drm;
 };

--- a/include/backend/udev.h
+++ b/include/backend/udev.h
@@ -1,18 +1,29 @@
 #ifndef _WLR_INTERNAL_UDEV_H
 #define _WLR_INTERNAL_UDEV_H
 
+#include <sys/types.h>
 #include <libudev.h>
 #include <wlr/session.h>
 #include <wayland-server.h>
 #include <wlr/backend/udev.h>
 
+struct wlr_udev_dev {
+	dev_t dev;
+	struct wl_signal invalidate;
+
+	struct wl_list link;
+};
+
 struct wlr_udev {
 	struct udev *udev;
 	struct udev_monitor *mon;
 	struct wl_event_source *event;
-	struct wl_signal invalidate_drm;
+
+	struct wl_list devices;
 };
 
 int wlr_udev_find_gpu(struct wlr_udev *udev, struct wlr_session *session);
+bool wlr_udev_signal_add(struct wlr_udev *udev, dev_t dev, struct wl_listener *listener);
+void wlr_udev_signal_remove(struct wlr_udev *udev, struct wl_listener *listener);
 
 #endif


### PR DESCRIPTION
This just allows devices to not need to reconfigure themselves if they get a udev event not intended for them.
This should allow multiple DRM backends to share a wlr_udev.