### PR TITLE
Logging improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 
 add_definitions(-DWLR_GIT_VERSION=\"${GIT_COMMIT_HASH}\")
 add_definitions(-DWLR_GIT_BRANCH=\"${GIT_BRANCH}\")
+add_definitions(-DWLR_SRC_DIR=\"${CMAKE_SOURCE_DIR}\")
 
 string(TIMESTAMP CURRENT_DATE "%Y-%m-%d" UTC)
 add_definitions(-DWLR_VERSION_DATE=\"${CURRENT_DATE}\")

--- a/common/log.c
+++ b/common/log.c
@@ -10,7 +10,7 @@
 #include "common/log.h"
 
 static bool colored = true;
-static log_callback_t log_callback;
+static log_callback_t log_callback = wlr_log_stderr;
 
 static const char *verbosity_colors[] = {
 	[L_SILENT] = "",
@@ -21,46 +21,26 @@ static const char *verbosity_colors[] = {
 
 void wlr_log_init(log_callback_t callback) {
 	log_callback = callback;
-	// TODO: Use log callback
 }
 
-void _wlr_vlog(const char *filename, int line, log_importance_t verbosity,
-		const char *format, va_list args) {
+void wlr_log_stderr(log_importance_t verbosity, const char *fmt, va_list args) {
 	// prefix the time to the log message
-	static struct tm result;
-	static time_t t;
-	static struct tm *tm_info;
+	struct tm result;
+	time_t t = time(NULL);
+	struct tm *tm_info = localtime_r(&t, &result);
 	char buffer[26];
 
-	// get current time
-	t = time(NULL);
-	// convert time to local time (determined by the locale)
-	tm_info = localtime_r(&t, &result);
 	// generate time prefix
-	strftime(buffer, sizeof(buffer), "%x %X - ", tm_info);
+	strftime(buffer, sizeof(buffer), "%F %T - ", tm_info);
 	fprintf(stderr, "%s", buffer);
 
-	unsigned int c = verbosity;
-	if (c > sizeof(verbosity_colors) / sizeof(char *) - 1) {
-		c = sizeof(verbosity_colors) / sizeof(char *) - 1;
-	}
+	unsigned c = (verbosity < L_LAST) ? verbosity : L_LAST - 1;
 
 	if (colored && isatty(STDERR_FILENO)) {
 		fprintf(stderr, "%s", verbosity_colors[c]);
 	}
 
-	if (filename && line) {
-		const char *file = filename + strlen(filename);
-		while (file != filename && *file != '/') {
-			--file;
-		}
-		if (*file == '/') {
-			++file;
-		}
-		fprintf(stderr, "[%s:%d] ", file, line);
-	}
-
-	vfprintf(stderr, format, args);
+	vfprintf(stderr, fmt, args);
 
 	if (colored && isatty(STDERR_FILENO)) {
 		fprintf(stderr, "\x1B[0m");
@@ -68,33 +48,13 @@ void _wlr_vlog(const char *filename, int line, log_importance_t verbosity,
 	fprintf(stderr, "\n");
 }
 
-void _wlr_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) {
-	va_list args;
-	va_start(args, format);
-	_wlr_vlog(filename, line, verbosity, format, args);
-	va_end(args);
+void _wlr_vlog(log_importance_t verbosity, const char *fmt, va_list args) {
+	log_callback(verbosity, fmt, args);
 }
 
-void wlr_log_errno(log_importance_t verbosity, char* format, ...) {
-	unsigned int c = verbosity;
-	if (c > sizeof(verbosity_colors) / sizeof(char *) - 1) {
-		c = sizeof(verbosity_colors) / sizeof(char *) - 1;
-	}
-
-	if (isatty(STDERR_FILENO)) {
-		fprintf(stderr, "%s", verbosity_colors[c]);
-	}
-
+void _wlr_log(log_importance_t verbosity, const char *fmt, ...) {
 	va_list args;
-	va_start(args, format);
-	vfprintf(stderr, format, args);
+	va_start(args, fmt);
+	log_callback(verbosity, fmt, args);
 	va_end(args);
-
-	fprintf(stderr, ": ");
-	fprintf(stderr, "%s", strerror(errno));
-
-	if (isatty(STDERR_FILENO)) {
-		fprintf(stderr, "\x1B[0m");
-	}
-	fprintf(stderr, "\n");
 }

--- a/include/common/log.h
+++ b/include/common/log.h
@@ -14,20 +14,11 @@
 void _wlr_log(log_importance_t verbosity, const char *format, ...) ATTRIB_PRINTF(2, 3);
 void _wlr_vlog(log_importance_t verbosity, const char *format, va_list args) ATTRIB_PRINTF(2, 0);
 
-// Returns a filename relative to wlroots source directory
-static inline const char *_relpath(const char *file) {
-	const char *prefix = WLR_SRC_DIR;
-	if (strncmp(file, prefix, strlen(prefix)) == 0) {
-		file += strlen(prefix) + 1;
-	}
-	return file;
-}
-
 #define wlr_log(verb, fmt, ...) \
-	_wlr_log(verb, "[%s:%d] " fmt, _relpath(__FILE__), __LINE__, ##__VA_ARGS__)
+	_wlr_log(verb, "[%s:%d] " fmt, __FILE__ + strlen(WLR_SRC_DIR) + 1, __LINE__, ##__VA_ARGS__)
 
 #define wlr_vlog(verb, fmt, args) \
-	_wlr_vlog(verb, "[%s:%d] " fmt, _relpath(__FILE__), __LINE__, args)
+	_wlr_vlog(verb, "[%s:%d] " fmt, __FILE__ + strlen(WLR_SRC_DIR) + 1, __LINE__, args)
 
 #define wlr_log_errno(verb, fmt, ...) \
 	wlr_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))

--- a/include/common/log.h
+++ b/include/common/log.h
@@ -1,18 +1,35 @@
 #ifndef _WLR_INTERNAL_COMMON_LOG_H
 #define _WLR_INTERNAL_COMMON_LOG_H
 #include <stdbool.h>
+#include <string.h>
+#include <errno.h>
 #include <wlr/common/log.h>
 
-void wlr_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));
+#ifdef __GNUC__
+#define ATTRIB_PRINTF(start, end) __attribute__((format(printf, start, end)))
+#else
+#define ATTRIB_PRINTF(start, end)
+#endif
 
-void wlr_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));
+void _wlr_log(log_importance_t verbosity, const char *format, ...) ATTRIB_PRINTF(2, 3);
+void _wlr_vlog(log_importance_t verbosity, const char *format, va_list args) ATTRIB_PRINTF(2, 0);
 
-void _wlr_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) __attribute__((format(printf,4,5)));
+// Returns a filename relative to wlroots source directory
+static inline const char *_relpath(const char *file) {
+	const char *prefix = WLR_SRC_DIR;
+	if (strncmp(file, prefix, strlen(prefix)) == 0) {
+		file += strlen(prefix) + 1;
+	}
+	return file;
+}
 
-#define wlr_log(VERBOSITY, FMT, ...) \
-	_wlr_log(__FILE__, __LINE__, VERBOSITY, FMT, ##__VA_ARGS__)
+#define wlr_log(verb, fmt, ...) \
+	_wlr_log(verb, "[%s:%d] " fmt, _relpath(__FILE__), __LINE__, ##__VA_ARGS__)
 
-#define wlr_vlog(VERBOSITY, FMT, VA_ARGS) \
-    _wlr_vlog(__FILE__, __LINE__, VERBOSITY, FMT, VA_ARGS)
+#define wlr_vlog(verb, fmt, args) \
+	_wlr_vlog(verb, "[%s:%d] " fmt, _relpath(__FILE__), __LINE__, args)
+
+#define wlr_log_errno(verb, fmt, ...) \
+	wlr_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))
 
 #endif

--- a/include/wlr/common/log.h
+++ b/include/wlr/common/log.h
@@ -8,10 +8,12 @@ typedef enum {
 	L_ERROR = 1,
 	L_INFO = 2,
 	L_DEBUG = 3,
+	L_LAST,
 } log_importance_t;
 
 typedef void (*log_callback_t)(log_importance_t importance, const char *fmt, va_list args);
 
-void init_log(log_callback_t callback);
+void wlr_init_log(log_callback_t callback);
+void wlr_log_stderr(log_importance_t verbosity, const char *fmt, va_list args);
 
 #endif


### PR DESCRIPTION
Changes the logging to actually use the logging callback that the library user can set. It defaults to the current log function (what was _wlr_vlog).
The output message for the default log function has changed slightly: it uses the ISO 8601 date format instead of a locale dependant one (but the time zone is still locale dependent).
The filename is now relative to the wlroots directory instead of just the basename. We have multiple "backend.c"s, so this is to distinguish them.

This implementation uses preprocessor string concatenation, so we can't pass a non-string literal as the format string to the logging functions anymore, but I think that's fine. Passing a non-string literal would be a mistake, anyway.

There is also a static inline function inside the header. This is so that the compiler can optimise the offset calculation out, so it doesn't have to be recalculated every time a logging function is called. I've viewed the assembly output with optimisations enabled, and it does work.