### PR TITLE
Make logging ninja friendly

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -65,22 +65,13 @@ void _wlr_log(log_importance_t verbosity, const char *fmt, ...) {
 // '../backend/wayland/backend.c' will both be stripped to
 // 'backend/wayland/backend.c'
 const char *_strip_path(const char *filepath) {
-	const char *srcit = WLR_SRC_DIR;
-	const char *fileit = filepath;
-
-	// remove WLR_SRC_DIR prefix
-	while(*fileit != '\0' && *srcit != '\0' && *fileit == *srcit) {
-		++fileit;
-		++srcit;
+	static int srclen = strlen(WLR_SRC_DIR) + 1;
+	if(*filepath == '.') {
+		while(*filepath == '.' || *filepath == '/') {
+			++filepath;
+		}
+	} else {
+		filepath += srclen;
 	}
-	if(fileit != filepath) {
-		++fileit;
-	}
-
-	// remove relative prefix
-	while(*fileit == '.' || *fileit == '/') {
-		++fileit;
-	}
-
-	return fileit;
+	return filepath;
 }

--- a/common/log.c
+++ b/common/log.c
@@ -58,3 +58,29 @@ void _wlr_log(log_importance_t verbosity, const char *fmt, ...) {
 	log_callback(verbosity, fmt, args);
 	va_end(args);
 }
+
+// strips the path prefix from filepath
+// will try to strip WLR_SRC_DIR as well as a relative src dir
+// e.g. '/src/build/wlroots/backend/wayland/backend.c' and
+// '../backend/wayland/backend.c' will both be stripped to
+// 'backend/wayland/backend.c'
+const char *_strip_path(const char *filepath) {
+	const char *srcit = WLR_SRC_DIR;
+	const char *fileit = filepath;
+
+	// remove WLR_SRC_DIR prefix
+	while(*fileit != '\0' && *srcit != '\0' && *fileit == *srcit) {
+		++fileit;
+		++srcit;
+	}
+	if(fileit != filepath) {
+		++fileit;
+	}
+
+	// remove relative prefix
+	while(*fileit == '.' || *fileit == '/') {
+		++fileit;
+	}
+
+	return fileit;
+}

--- a/include/common/log.h
+++ b/include/common/log.h
@@ -13,12 +13,13 @@
 
 void _wlr_log(log_importance_t verbosity, const char *format, ...) ATTRIB_PRINTF(2, 3);
 void _wlr_vlog(log_importance_t verbosity, const char *format, va_list args) ATTRIB_PRINTF(2, 0);
+const char *_strip_path(const char *filepath);
 
 #define wlr_log(verb, fmt, ...) \
-	_wlr_log(verb, "[%s:%d] " fmt, __FILE__ + strlen(WLR_SRC_DIR) + 1, __LINE__, ##__VA_ARGS__)
+	_wlr_log(verb, "[%s:%d] " fmt, _strip_path(__FILE__), __LINE__, ##__VA_ARGS__)
 
 #define wlr_vlog(verb, fmt, args) \
-	_wlr_vlog(verb, "[%s:%d] " fmt, __FILE__ + strlen(WLR_SRC_DIR) + 1, __LINE__, args)
+	_wlr_vlog(verb, "[%s:%d] " fmt, _strip_path(__FILE__), __LINE__, args)
 
 #define wlr_log_errno(verb, fmt, ...) \
 	wlr_log(verb, fmt ": %s", ##__VA_ARGS__, strerror(errno))


### PR DESCRIPTION
When building with ninja instead of make ```__FILE__``` will be relative
and logging therefore break. This moves stripping the path
from ```__FILE__``` to runtime and handles a relative filepath as
well as a full one.