### PR TITLE
Fix VT switching with libinput backend

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -54,8 +54,10 @@ static void session_signal(struct wl_listener *listener, void *data) {
 	} else {
 		wlr_log(L_INFO, "DRM fd paused");
 
-		// TODO: Actually pause the renderer or something.
-		// We currently just expect it to fail its next pageflip.
+		for (size_t i = 0; i < drm->outputs->length; ++i) {
+			struct wlr_output_state *output = drm->outputs->items[i];
+			wlr_drm_output_pause_renderer(output);
+		}
 	}
 }
 

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -116,6 +116,21 @@ static void wlr_drm_output_end(struct wlr_output_state *output) {
 	output->bo[0] = bo;
 }
 
+void wlr_drm_output_pause_renderer(struct wlr_output_state *output) {
+	if (output->state != DRM_OUTPUT_CONNECTED) {
+		return;
+	}
+
+	if (output->bo[1]) {
+		gbm_surface_release_buffer(output->gbm, output->bo[1]);
+		output->bo[1] = NULL;
+	}
+	if (output->bo[0]) {
+		gbm_surface_release_buffer(output->gbm, output->bo[0]);
+		output->bo[0] = NULL;
+	}
+}
+
 void wlr_drm_output_start_renderer(struct wlr_output_state *output) {
 	if (output->state != DRM_OUTPUT_CONNECTED) {
 		return;
@@ -608,7 +623,7 @@ static void page_flip_handler(int fd, unsigned seq,
 	}
 
 	output->pageflip_pending = false;
-	if (output->state == DRM_OUTPUT_CONNECTED) {
+	if (output->state == DRM_OUTPUT_CONNECTED && state->session->active) {
 		wlr_drm_output_begin(output);
 		wl_signal_emit(&output->wlr_output->events.frame, output->wlr_output);
 		wlr_drm_output_end(output);

--- a/example/pointer.c
+++ b/example/pointer.c
@@ -50,6 +50,8 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 		xkb_keysym_t sym, enum wlr_key_state key_state) {
 	if (sym == XKB_KEY_Escape) {
 		kbstate->compositor->exit = true;
+	} else if (key_state == WLR_KEY_PRESSED && sym >= XKB_KEY_F1 && sym <= XKB_KEY_F12) {
+		wlr_session_change_vt(kbstate->compositor->session, sym - XKB_KEY_F1 + 1);
 	}
 }
 

--- a/example/rotation.c
+++ b/example/rotation.c
@@ -123,6 +123,10 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 			update_velocities(kbstate->compositor, 0, 16);
 			break;
 		}
+
+		if (sym >= XKB_KEY_F1 && sym <= XKB_KEY_F12) {
+			wlr_session_change_vt(kbstate->compositor->session, sym - XKB_KEY_F1 + 1);
+		}
 	}
 }
 

--- a/example/simple.c
+++ b/example/simple.c
@@ -42,6 +42,8 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 		xkb_keysym_t sym, enum wlr_key_state key_state) {
 	if (sym == XKB_KEY_Escape) {
 		kbstate->compositor->exit = true;
+	} else if (sym >= XKB_KEY_F1 && sym <= XKB_KEY_F12) {
+		wlr_session_change_vt(kbstate->compositor->session, sym - XKB_KEY_F1 + 1);
 	}
 }
 

--- a/example/simple.c
+++ b/example/simple.c
@@ -42,7 +42,7 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 		xkb_keysym_t sym, enum wlr_key_state key_state) {
 	if (sym == XKB_KEY_Escape) {
 		kbstate->compositor->exit = true;
-	} else if (sym >= XKB_KEY_F1 && sym <= XKB_KEY_F12) {
+	} else if (key_state == WLR_KEY_PRESSED && sym >= XKB_KEY_F1 && sym <= XKB_KEY_F12) {
 		wlr_session_change_vt(kbstate->compositor->session, sym - XKB_KEY_F1 + 1);
 	}
 }

--- a/example/tablet.c
+++ b/example/tablet.c
@@ -78,6 +78,8 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 		xkb_keysym_t sym, enum wlr_key_state key_state) {
 	if (sym == XKB_KEY_Escape) {
 		kbstate->compositor->exit = true;
+	} else if (key_state == WLR_KEY_PRESSED && sym >= XKB_KEY_F1 && sym <= XKB_KEY_F12) {
+		wlr_session_change_vt(kbstate->compositor->session, sym - XKB_KEY_F1 + 1);
 	}
 }
 

--- a/example/touch.c
+++ b/example/touch.c
@@ -59,6 +59,8 @@ static void handle_keyboard_key(struct keyboard_state *kbstate,
 		xkb_keysym_t sym, enum wlr_key_state key_state) {
 	if (sym == XKB_KEY_Escape) {
 		kbstate->compositor->exit = true;
+	} else if (key_state == WLR_KEY_PRESSED && sym >= XKB_KEY_F1 && sym <= XKB_KEY_F12) {
+		wlr_session_change_vt(kbstate->compositor->session, sym - XKB_KEY_F1 + 1);
 	}
 }
 

--- a/include/backend/drm.h
+++ b/include/backend/drm.h
@@ -89,5 +89,6 @@ void wlr_drm_scan_connectors(struct wlr_backend_state *state);
 int wlr_drm_event(int fd, uint32_t mask, void *data);
 
 void wlr_drm_output_start_renderer(struct wlr_output_state *output);
+void wlr_drm_output_pause_renderer(struct wlr_output_state *output);
 
 #endif

--- a/include/backend/drm.h
+++ b/include/backend/drm.h
@@ -34,8 +34,7 @@ struct wlr_backend_state {
 	struct wlr_backend *backend;
 	struct wl_event_source *drm_event;
 
-	struct wl_listener device_paused;
-	struct wl_listener device_resumed;
+	struct wl_listener session_signal;
 	struct wl_listener drm_invalidated;
 
 	uint32_t taken_crtcs;

--- a/include/backend/libinput.h
+++ b/include/backend/libinput.h
@@ -16,6 +16,8 @@ struct wlr_backend_state {
 	struct libinput *libinput;
 	struct wl_event_source *input_event;
 
+	struct wl_listener session_signal;
+
 	list_t *devices;
 };
 

--- a/include/wlr/session.h
+++ b/include/wlr/session.h
@@ -1,22 +1,17 @@
 #ifndef WLR_SESSION_H
 #define WLR_SESSION_H
 
+#include <stdbool.h>
 #include <wayland-server.h>
 #include <sys/types.h>
 
 struct session_impl;
 
-// Passed to the listeners of device_paused/resumed
-struct device_arg {
-	dev_t dev;
-	int fd; // Only for device_resumed
-};
-
 struct wlr_session {
 	const struct session_impl *impl;
 
-	struct wl_signal device_paused;
-	struct wl_signal device_resumed;
+	bool active;
+	struct wl_signal session_signal;
 };
 
 struct wlr_session *wlr_session_start(struct wl_display *disp);

--- a/session/direct.c
+++ b/session/direct.c
@@ -45,8 +45,8 @@ static struct wlr_session *direct_session_start(struct wl_display *disp) {
 	wlr_log(L_INFO, "Successfully loaded direct session");
 
 	session->base.impl = &session_direct;
-	wl_signal_init(&session->base.device_paused);
-	wl_signal_init(&session->base.device_resumed);
+	session->base.active = true;
+	wl_signal_init(&session->base.session_signal);
 	return &session->base;
 }
 

--- a/session/logind.c
+++ b/session/logind.c
@@ -35,7 +35,6 @@ static int logind_take_device(struct wlr_session *restrict base,
 		const char *restrict path) {
 	struct logind_session *session = wl_container_of(base, session, base);
 
-	wlr_log(L_DEBUG, "Taking '%s'", path);
 	int ret;
 	int fd = -1;
 	sd_bus_message *msg = NULL;
@@ -209,7 +208,6 @@ static int pause_device(sd_bus_message *msg, void *userdata, sd_bus_error *ret_e
 			strerror(-ret));
 		goto error;
 	}
-	wlr_log(L_INFO, "PauseDevice signal received: (%lu) %s", makedev(major, minor), type);
 
 	if (major == DRM_MAJOR) {
 		session->base.active = false;
@@ -242,7 +240,6 @@ static int resume_device(sd_bus_message *msg, void *userdata, sd_bus_error *ret_
 			strerror(-ret));
 		goto error;
 	}
-	wlr_log(L_INFO, "ResumeDevice signal received (%lu)", makedev(major, minor));
 
 	if (major == DRM_MAJOR) {
 		dup2(fd, session->drm_fd);


### PR DESCRIPTION
The session interface was also changed to only emit a signal only when a DRM device is paused/resumed. The old per-device interface wasn't really appropriate for libinput, as it acquires dozens of devices, and we can't tell it to close them individually. This brings it more in line with the way Weston handles this.

The logind backend currently makes some assumptions that there is only a single DRM device being used. If/when we get multi-GPU support, this will need to be changed, but until I know what using multiple GPUs and DRM backends would look like, I can't really see how this needs to be designed.