### PR TITLE
Basic wayland backend input

### DIFF
--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -63,7 +63,7 @@ static bool wlr_wl_backend_init(struct wlr_backend_state* state) {
 	state->remote_display_src = wl_event_loop_add_fd(loop, fd, events,
 			dispatch_events, state);
 	wl_event_source_check(state->remote_display_src);
-
+	
 	return true;
 }
 
@@ -76,14 +76,14 @@ static void wlr_wl_backend_destroy(struct wlr_backend_state *state) {
 		wlr_output_destroy(state->outputs->items[i]);
 	}
 
-	for (size_t i = 0; state->devices && i < state->devices->length; ++i) {
+	for (size_t i = 0; i < state->devices->length; ++i) {
 		wlr_input_device_destroy(state->devices->items[i]);
 	}
 
 	list_free(state->devices);
+	list_free(state->outputs);
 
 	wlr_egl_free(&state->egl);
-	free(state->outputs);
 	if (state->seat) wl_seat_destroy(state->seat);
 	if (state->shm) wl_shm_destroy(state->shm);
 	if (state->shell) wl_shell_destroy(state->shell);
@@ -133,9 +133,8 @@ struct wlr_backend *wlr_wl_backend_create(struct wl_display *display) {
 
 error:
 	if (state) {
-		free(state->outputs);
-		free(state->devices);
-		free(state->devices);
+		list_free(state->devices);
+		list_free(state->outputs);
 	}
 	free(state);
 	free(backend);

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -63,7 +63,7 @@ static bool wlr_wl_backend_init(struct wlr_backend_state* state) {
 	state->remote_display_src = wl_event_loop_add_fd(loop, fd, events,
 			dispatch_events, state);
 	wl_event_source_check(state->remote_display_src);
-	
+
 	return true;
 }
 
@@ -100,6 +100,17 @@ static struct wlr_backend_impl backend_impl = {
 
 bool wlr_backend_is_wl(struct wlr_backend *b) {
 	return b->impl == &backend_impl;
+}
+
+struct wlr_output *wlr_wl_output_for_surface(struct wlr_backend_state *backend,
+	struct wl_surface *surface) {
+	for (size_t i = 0; i < backend->outputs->length; ++i) {
+		struct wlr_output *output = backend->outputs->items[i];
+		if(output->state->surface == surface)
+			return output;
+	}
+
+	return NULL;
 }
 
 struct wlr_backend *wlr_wl_backend_create(struct wl_display *display) {

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -33,15 +33,21 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 	assert(dev && dev->pointer && dev->pointer->state);
 	struct wlr_pointer_state *state = dev->pointer->state;
 
+	double x = wl_fixed_to_double(surface_x);
+	double y = wl_fixed_to_double(surface_y);
+
+	if (x == state->surface_x && y == state->surface_y)
+		return;
+
 	struct wlr_event_pointer_motion wlr_event;
 	wlr_event.time_sec = time / 1000;
 	wlr_event.time_usec = time * 1000;
-	wlr_event.delta_x = wl_fixed_to_double(surface_x) - state->surface_x;
-	wlr_event.delta_y = wl_fixed_to_double(surface_y) - state->surface_y;
+	wlr_event.delta_x = x - state->surface_x;
+	wlr_event.delta_y = y - state->surface_y;
 	wl_signal_emit(&dev->pointer->events.motion, &wlr_event);
 
-	state->surface_x = surface_x;
-	state->surface_y = surface_y;
+	state->surface_x = x;
+	state->surface_y = y;
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -11,12 +11,109 @@
 #include <wlr/util/log.h>
 #include "backend/wayland.h"
 
-static void wlr_wl_device_destroy(struct wlr_input_device_state *state) {
+static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
+		uint32_t serial, struct wl_surface *surface, wl_fixed_t surface_x,
+		wl_fixed_t surface_y) {
+
+}
+
+static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
+		uint32_t serial, struct wl_surface *surface) {
+
+}
+
+static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
+
+}
+
+static void pointer_handle_button(void *data, struct wl_pointer *wl_pointer,
+		uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
+
+}
+
+static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, uint32_t axis, wl_fixed_t value) {
+
+}
+
+static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
+
+}
+
+static void pointer_handle_axis_source(void *data, struct wl_pointer *wl_pointer,
+		uint32_t axis_source) {
+
+}
+
+static void pointer_handle_axis_stop(void *data, struct wl_pointer *wl_pointer,
+		uint32_t time, uint32_t axis) {
+
+}
+
+static void pointer_handle_axis_discrete(void *data, struct wl_pointer *wl_pointer,
+		uint32_t axis, int32_t discrete) {
+
+}
+
+static const struct wl_pointer_listener pointer_listener = {
+	.enter = pointer_handle_enter,
+	.leave = pointer_handle_leave,
+	.motion = pointer_handle_motion,
+	.button = pointer_handle_button,
+	.axis = pointer_handle_axis,
+	.frame = pointer_handle_frame,
+	.axis_source = pointer_handle_axis_source,
+	.axis_stop = pointer_handle_axis_stop,
+	.axis_discrete = pointer_handle_axis_discrete
+};
+
+static void keyboard_handle_keymap(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t format, int32_t fd, uint32_t size) {
+
+}
+
+static void keyboard_handle_enter(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, struct wl_surface *surface, struct wl_array *keys) {
+
+}
+
+static void keyboard_handle_leave(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, struct wl_surface *surface) {
+
+}
+
+static void keyboard_handle_key(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, uint32_t time, uint32_t key, uint32_t state) {
+
+}
+
+static void keyboard_handle_modifiers(void *data, struct wl_keyboard *wl_keyboard,
+		uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched,
+		uint32_t mods_locked, uint32_t group) {
+
+}
+
+static void keyboard_handle_repeat_info(void *data, struct wl_keyboard *wl_keyboard,
+	int32_t rate, int32_t delay) {
+
+}
+
+static struct wl_keyboard_listener keyboard_listener = {
+	.keymap = keyboard_handle_keymap,
+	.enter = keyboard_handle_enter,
+	.leave = keyboard_handle_leave,
+	.key = keyboard_handle_key,
+	.modifiers = keyboard_handle_modifiers,
+	.repeat_info = keyboard_handle_repeat_info
+};
+
+static void input_device_destroy(struct wlr_input_device_state *state) {
 	free(state);
 }
 
 static struct wlr_input_device_impl input_device_impl = {
-	.destroy = wlr_wl_device_destroy
+	.destroy = input_device_destroy
 };
 
 static struct wlr_input_device *allocate_device(struct wlr_backend_state *state,
@@ -49,7 +146,6 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 	struct wlr_backend_state *state = data;
 	assert(state->seat == wl_seat);
 
-	// TODO: add listeners and receive input
 	if ((caps & WL_SEAT_CAPABILITY_POINTER)) {
 		wlr_log(L_DEBUG, "seat %p offered pointer", wl_seat);
 		struct wl_pointer *wl_pointer = wl_seat_get_pointer(wl_seat);

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -30,7 +30,9 @@ static void pointer_handle_enter(void *data, struct wl_pointer *wl_pointer,
 
 static void pointer_handle_leave(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, struct wl_surface *surface) {
-
+	struct wlr_input_device *dev = data;
+	assert(dev && dev->pointer && dev->pointer->state);
+	dev->pointer->state->current_output = NULL;
 }
 
 static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
@@ -38,7 +40,11 @@ static void pointer_handle_motion(void *data, struct wl_pointer *wl_pointer,
 	struct wlr_input_device *dev = data;
 	assert(dev && dev->pointer && dev->pointer->state);
 	struct wlr_pointer_state *state = dev->pointer->state;
-	assert(state->current_output);
+
+	if(!state->current_output) {
+		wlr_log(L_ERROR, "pointer motion event without current output");
+		return;
+	}
 
 	int width, height;
 	wl_egl_window_get_attached_size(state->current_output->state->egl_window,

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -77,7 +77,7 @@ static void pointer_handle_axis(void *data, struct wl_pointer *wl_pointer,
 	wlr_event.orientation = axis;
 	wlr_event.time_sec = time / 1000;
 	wlr_event.time_usec = time * 1000;
-	wlr_event.source = WLR_AXIS_SOURCE_CONTINUOUS;
+	wlr_event.source = dev->pointer->state->axis_source;
 	wl_signal_emit(&dev->pointer->events.axis, &wlr_event);
 }
 
@@ -87,7 +87,9 @@ static void pointer_handle_frame(void *data, struct wl_pointer *wl_pointer) {
 
 static void pointer_handle_axis_source(void *data, struct wl_pointer *wl_pointer,
 		uint32_t axis_source) {
-
+	struct wlr_input_device *dev = data;
+	assert(dev && dev->pointer && dev->pointer->state);
+	dev->pointer->state->axis_source = axis_source;
 }
 
 static void pointer_handle_axis_stop(void *data, struct wl_pointer *wl_pointer,

--- a/example/pointer.c
+++ b/example/pointer.c
@@ -54,6 +54,13 @@ static void handle_pointer_motion(struct pointer_state *pstate,
 	state->cur_y += d_y;
 }
 
+static void handle_pointer_motion_absolute(struct pointer_state *pstate,
+		double x, double y) {
+	struct sample_state *state = pstate->compositor->data;
+	state->cur_x = x;
+	state->cur_y = y;
+}
+
 static void handle_pointer_button(struct pointer_state *pstate,
 		uint32_t button, enum wlr_button_state state) {
 	struct sample_state *sample = pstate->compositor->data;
@@ -109,6 +116,7 @@ int main(int argc, char *argv[]) {
 	compositor.output_add_cb = handle_output_add;
 	compositor.output_frame_cb = handle_output_frame;
 	compositor.pointer_motion_cb = handle_pointer_motion;
+	compositor.pointer_motion_absolute_cb = handle_pointer_motion_absolute;
 	compositor.pointer_button_cb = handle_pointer_button;
 	compositor.pointer_axis_cb = handle_pointer_axis;
 	compositor_init(&compositor);

--- a/example/shared.c
+++ b/example/shared.c
@@ -105,6 +105,15 @@ static void pointer_motion_notify(struct wl_listener *listener, void *data) {
 	}
 }
 
+static void pointer_motion_absolute_notify(struct wl_listener *listener, void *data) {
+	struct wlr_event_pointer_motion_absolute *event = data;
+	struct pointer_state *pstate = wl_container_of(listener, pstate, motion_absolute);
+	if (pstate->compositor->pointer_motion_absolute_cb) {
+		pstate->compositor->pointer_motion_absolute_cb(pstate,
+				event->x_mm, event->y_mm);
+	}
+}
+
 static void pointer_button_notify(struct wl_listener *listener, void *data) {
 	struct wlr_event_pointer_button *event = data;
 	struct pointer_state *pstate = wl_container_of(listener, pstate, button);
@@ -132,9 +141,11 @@ static void pointer_add(struct wlr_input_device *device, struct compositor_state
 	wl_list_init(&pstate->button.link);
 	wl_list_init(&pstate->axis.link);
 	pstate->motion.notify = pointer_motion_notify;
+	pstate->motion_absolute.notify = pointer_motion_absolute_notify;
 	pstate->button.notify = pointer_button_notify;
 	pstate->axis.notify = pointer_axis_notify;
 	wl_signal_add(&device->pointer->events.motion, &pstate->motion);
+	wl_signal_add(&device->pointer->events.motion_absolute, &pstate->motion_absolute);
 	wl_signal_add(&device->pointer->events.button, &pstate->button);
 	wl_signal_add(&device->pointer->events.axis, &pstate->axis);
 	wl_list_insert(&state->pointers, &pstate->link);
@@ -308,7 +319,7 @@ static void pointer_remove(struct wlr_input_device *device, struct compositor_st
 	}
 	wl_list_remove(&pstate->link);
 	wl_list_remove(&pstate->motion.link);
-	//wl_list_remove(&pstate->motion_absolute.link);
+	wl_list_remove(&pstate->motion_absolute.link);
 	wl_list_remove(&pstate->button.link);
 	wl_list_remove(&pstate->axis.link);
 }

--- a/example/shared.h
+++ b/example/shared.h
@@ -83,6 +83,8 @@ struct compositor_state {
 			enum wlr_key_state key_state);
 	void (*pointer_motion_cb)(struct pointer_state *s,
 			double d_x, double d_y);
+	void (*pointer_motion_absolute_cb)(struct pointer_state *s,
+			double x, double y);
 	void (*pointer_button_cb)(struct pointer_state *s,
 			uint32_t button, enum wlr_button_state state);
 	void (*pointer_axis_cb)(struct pointer_state *s,

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -39,16 +39,17 @@ struct wlr_output_state {
 };
 
 struct wlr_input_device_state {
-	enum wlr_input_device_type type;
+	struct wlr_backend_state* backend;
 	void *resource;
 };
 
 struct wlr_pointer_state {
-	double surface_x;
-	double surface_y;
+	struct wlr_output *current_output;
 };
 
 void wlr_wl_registry_poll(struct wlr_backend_state *backend);
+struct wlr_output *wlr_wl_output_for_surface(struct wlr_backend_state *backend,
+	struct wl_surface *surface);
 
 extern const struct wl_seat_listener seat_listener;
 

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -43,6 +43,11 @@ struct wlr_input_device_state {
 	void *resource;
 };
 
+struct wlr_pointer_state {
+	double surface_x;
+	double surface_y;
+};
+
 void wlr_wl_registry_poll(struct wlr_backend_state *backend);
 
 extern const struct wl_seat_listener seat_listener;

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -44,6 +44,7 @@ struct wlr_input_device_state {
 };
 
 struct wlr_pointer_state {
+	enum wlr_axis_source axis_source;
 	struct wlr_output *current_output;
 };
 


### PR DESCRIPTION
This implements pointer/keyboard input support for the wayland backend.
Touch is not supported yet in any way (cannot test it, probably not as important).
Axis support for pointers could also be improved and it does currently not handle the received keymap (there is no way to do it, xkbcommon would have to be handled by the library).
Due to the current pointer event api, pointer movement events are only handled relatively (not sure about this, should it use wlr_event_pointer_motion_absolute and just imagine some fake mm values?).