### PR TITLE
Software cursor + Hardware cursor improvements

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -313,7 +313,7 @@ static bool wlr_drm_output_set_cursor(struct wlr_output_state *output,
 	bo_height = ret ? 64 : bo_height;
 
 	if (width > bo_width || height > bo_width) {
-		wlr_log(L_INFO, "Cursor too large");
+		wlr_log(L_INFO, "Cursor too large (max %dx%d)", (int)bo_width, (int)bo_height);
 		return false;
 	}
 

--- a/example/rotation.c
+++ b/example/rotation.c
@@ -46,6 +46,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
+	wlr_output_make_current(wlr_output);
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	float matrix[16];
@@ -59,6 +60,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	}
 
 	wlr_renderer_end(sample->renderer);
+	wlr_output_swap_buffers(wlr_output);
 
 	long ms = (ts->tv_sec - output->last_frame.tv_sec) * 1000 +
 		(ts->tv_nsec - output->last_frame.tv_nsec) / 1000000;
@@ -205,7 +207,7 @@ int main(int argc, char *argv[]) {
 	state.renderer = wlr_gles2_renderer_init();
 	state.cat_texture = wlr_render_surface_init(state.renderer);
 	wlr_surface_attach_pixels(state.cat_texture, GL_RGBA,
-		cat_tex.width, cat_tex.height, cat_tex.pixel_data);
+		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);
 
 	compositor_run(&compositor);
 

--- a/example/simple.c
+++ b/example/simple.c
@@ -34,8 +34,12 @@ void handle_output_frame(struct output_state *output, struct timespec *ts) {
 		sample->dec = inc;
 	}
 
+	wlr_output_make_current(output->output);
+
 	glClearColor(sample->color[0], sample->color[1], sample->color[2], 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
+
+	wlr_output_swap_buffers(output->output);
 }
 
 int main() {

--- a/example/tablet.c
+++ b/example/tablet.c
@@ -41,6 +41,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
 
+	wlr_output_make_current(wlr_output);
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	float matrix[16], view[16];
@@ -74,6 +75,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	}
 
 	wlr_renderer_end(sample->renderer);
+	wlr_output_swap_buffers(wlr_output);
 }
 
 static void handle_tool_axis(struct tablet_tool_state *tstate,

--- a/example/touch.c
+++ b/example/touch.c
@@ -38,6 +38,8 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 
 	int32_t width, height;
 	wlr_output_effective_resolution(wlr_output, &width, &height);
+
+	wlr_output_make_current(wlr_output);
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	float matrix[16];
@@ -52,6 +54,7 @@ static void handle_output_frame(struct output_state *output, struct timespec *ts
 	}
 
 	wlr_renderer_end(sample->renderer);
+	wlr_output_swap_buffers(wlr_output);
 }
 
 static void handle_touch_down(struct touch_state *tstate, int32_t slot,
@@ -104,7 +107,7 @@ int main(int argc, char *argv[]) {
 	state.renderer = wlr_gles2_renderer_init();
 	state.cat_texture = wlr_render_surface_init(state.renderer);
 	wlr_surface_attach_pixels(state.cat_texture, GL_RGBA,
-		cat_tex.width, cat_tex.height, cat_tex.pixel_data);
+		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);
 
 	compositor_run(&compositor);
 

--- a/include/wlr/interfaces/wlr_output.h
+++ b/include/wlr/interfaces/wlr_output.h
@@ -13,6 +13,8 @@ struct wlr_output_impl {
 		const uint8_t *buf, int32_t stride, uint32_t width, uint32_t height);
 	bool (*move_cursor)(struct wlr_output_state *state, int x, int y);
 	void (*destroy)(struct wlr_output_state *state);
+	void (*make_current)(struct wlr_output_state *state);
+	void (*swap_buffers)(struct wlr_output_state *state);
 };
 
 struct wlr_output *wlr_output_create(struct wlr_output_impl *impl,

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -59,7 +59,7 @@ struct wlr_surface {
  * calling this function.
  */
 bool wlr_surface_attach_pixels(struct wlr_surface *surf, uint32_t format,
-		int width, int height, const unsigned char *pixels);
+		int stride, int width, int height, const unsigned char *pixels);
 /**
  * Attaches pixels from a wl_shm_buffer to this surface. The shm buffer may be
  * invalidated after calling this function.

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -31,7 +31,7 @@ struct wlr_renderer *wlr_renderer_init(struct wlr_renderer_state *state,
 
 struct wlr_surface_impl {
 	bool (*attach_pixels)(struct wlr_surface_state *state, uint32_t format,
-		int width, int height, const unsigned char *pixels);
+		int stride, int width, int height, const unsigned char *pixels);
 	bool (*attach_shm)(struct wlr_surface_state *state, uint32_t format,
 		struct wl_shm_buffer *shm);
 	// TODO: egl

--- a/include/wlr/types/wlr_output.h
+++ b/include/wlr/types/wlr_output.h
@@ -42,6 +42,14 @@ struct wlr_output {
 		struct wl_signal frame;
 		struct wl_signal resolution;
 	} events;
+
+	struct {
+		bool is_sw;
+		int32_t x, y;
+		uint32_t width, height;
+		struct wlr_renderer *renderer;
+		struct wlr_surface *texture;
+	} cursor;
 };
 
 void wlr_output_enable(struct wlr_output *output, bool enable);
@@ -55,5 +63,7 @@ bool wlr_output_move_cursor(struct wlr_output *output, int x, int y);
 void wlr_output_destroy(struct wlr_output *output);
 void wlr_output_effective_resolution(struct wlr_output *output,
 		int *width, int *height);
+void wlr_output_make_current(struct wlr_output *output);
+void wlr_output_swap_buffers(struct wlr_output *output);
 
 #endif

--- a/render/CMakeLists.txt
+++ b/render/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_library(wlr-render STATIC
-	matrix.c
+add_library(wlr-render
+    matrix.c
     wlr_renderer.c
     wlr_surface.c
     gles2/shaders.c

--- a/render/gles2/surface.c
+++ b/render/gles2/surface.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
 #include <wayland-util.h>
 #include <wayland-server-protocol.h>
 #include <wlr/render.h>
@@ -10,15 +11,17 @@
 #include "render/gles2.h"
 
 static bool gles2_surface_attach_pixels(struct wlr_surface_state *surface,
-		uint32_t format, int width, int height, const unsigned char *pixels) {
+		uint32_t format, int stride, int width, int height, const unsigned char *pixels) {
 	assert(surface);
 	surface->wlr_surface->width = width;
 	surface->wlr_surface->height = height;
 	surface->wlr_surface->format = format;
 	GL_CALL(glGenTextures(1, &surface->tex_id));
 	GL_CALL(glBindTexture(GL_TEXTURE_2D, surface->tex_id));
+	GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride));
 	GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0,
 			format, GL_UNSIGNED_BYTE, pixels));
+	GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0));
 	surface->wlr_surface->valid = true;
 	return true;
 }

--- a/render/wlr_surface.c
+++ b/render/wlr_surface.c
@@ -20,9 +20,9 @@ void wlr_surface_bind(struct wlr_surface *surface) {
 }
 
 bool wlr_surface_attach_pixels(struct wlr_surface *surface, uint32_t format,
-		int width, int height, const unsigned char *pixels) {
+		int stride, int width, int height, const unsigned char *pixels) {
 	return surface->impl->attach_pixels(surface->state,
-			format, width, height, pixels);
+			format, stride, width, height, pixels);
 }
 
 bool wlr_surface_attach_shm(struct wlr_surface *surface, uint32_t format,

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -15,5 +15,6 @@ add_library(wlr-types
 
 target_link_libraries(wlr-types
     wlr-util
+    wlr-render
     ${WAYLAND_LIBRARIES}
 )


### PR DESCRIPTION
Draw a cursor using wlr_renderer if a backend fails to draw a cursor. It also gives the option for a backend that doesn't want/need to handle cursors in a special way to just let this handle it.

There are also a couple of other changes, mainly to make this easier to implement.
- Changed the wlr_output 'frame' signal to *not* automatically make the EGL/OpenGL context current. The user must now explicitly call the new `wlr_output_make_current` and `wlr_output_swap_buffers` functions. This is mainly so the SW cursor can be drawn in swap buffers, but it also gives the user the option to draw something to an output whenever they want to.
- Added stride argument to `wlr_renderer_attach_pixels`. Also the GL_EXT_unpack_subimage extension is used to deal with the stride, so we don't have no needlessly copy a bunch of stuff ourselves. It currently doesn't check for the extension, but it's probably widely supported enough.