### PR TITLE
Forking session backend

### DIFF
--- a/CMake/FindLibcap.cmake
+++ b/CMake/FindLibcap.cmake
@@ -1,0 +1,56 @@
+#.rst:
+# FindLibcap
+# -------
+#
+# Find Libcap library
+#
+# Try to find Libcap library. The following values are defined
+#
+# ::
+#
+#   Libcap_FOUND         - True if Libcap is available
+#   Libcap_INCLUDE_DIRS  - Include directories for Libcap
+#   Libcap_LIBRARIES     - List of libraries for Libcap
+#   Libcap_DEFINITIONS   - List of definitions for Libcap
+#
+# and also the following more fine grained variables
+#
+# ::
+#
+#   Libcap_VERSION
+#   Libcap_VERSION_MAJOR
+#   Libcap_VERSION_MINOR
+#
+#=============================================================================
+# Copyright (c) 2017 Jerzi Kaminsky
+#
+# Distributed under the OSI-approved BSD License (the "License");
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+include(FeatureSummary)
+set_package_properties(Libcap PROPERTIES
+   URL "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2"
+   DESCRIPTION "Library for getting and setting POSIX.1e capabilities")
+
+find_package(PkgConfig)
+pkg_check_modules(PC_CAP QUIET Libcap)
+find_library(Libcap_LIBRARIES NAMES cap HINTS ${PC_CAP_LIBRARY_DIRS})
+find_path(Libcap_INCLUDE_DIRS sys/capability.h HINTS ${PC_CAP_INCLUDE_DIRS})
+
+set(Libcap_VERSION ${PC_CAP_VERSION})
+string(REPLACE "." ";" VERSION_LIST "${PC_CAP_VERSION}")
+
+LIST(LENGTH VERSION_LIST n)
+if (n EQUAL 2)
+   list(GET VERSION_LIST 0 Libcap_VERSION_MAJOR)
+   list(GET VERSION_LIST 1 Libcap_VERSION_MINOR)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libcap DEFAULT_MSG Libcap_INCLUDE_DIRS Libcap_LIBRARIES)
+mark_as_advanced(Libcap_INCLUDE_DIRS Libcap_LIBRARIES Libcap_DEFINITIONS
+   Libcap_VERSION Libcap_VERSION_MAJOR Libcap_VERSION_MICRO Libcap_VERSION_MINOR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(GBM REQUIRED)
 find_package(LibInput REQUIRED)
 find_package(XKBCommon REQUIRED)
 find_package(Udev REQUIRED)
-find_package(Libcap REQUIRED)
+find_package(Libcap)
 find_package(Systemd)
 
 include(Wayland)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ find_package(GBM REQUIRED)
 find_package(LibInput REQUIRED)
 find_package(XKBCommon REQUIRED)
 find_package(Udev REQUIRED)
+find_package(Libcap REQUIRED)
 find_package(Systemd)
 
 include(Wayland)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Install dependencies:
 * libinput
 * udev
 * systemd (optional, for logind support)
+* libcap (optional, for capability support)
 * asciidoc (optional, for man pages)
 
 Run these commands:

--- a/include/session/direct-ipc.h
+++ b/include/session/direct-ipc.h
@@ -1,0 +1,12 @@
+#ifndef SESSION_DIRECT_IPC
+#define SESSION_DIRECT_IPC
+
+#include <sys/types.h>
+
+int direct_ipc_open(int sock, const char *path);
+void direct_ipc_setmaster(int sock);
+void direct_ipc_dropmaster(int sock);
+void direct_ipc_finish(int sock, pid_t pid);
+int direct_ipc_start(pid_t *pid_out);
+
+#endif

--- a/include/session/direct-ipc.h
+++ b/include/session/direct-ipc.h
@@ -4,8 +4,8 @@
 #include <sys/types.h>
 
 int direct_ipc_open(int sock, const char *path);
-void direct_ipc_setmaster(int sock);
-void direct_ipc_dropmaster(int sock);
+void direct_ipc_setmaster(int sock, int fd);
+void direct_ipc_dropmaster(int sock, int fd);
 void direct_ipc_finish(int sock, pid_t pid);
 int direct_ipc_start(pid_t *pid_out);
 

--- a/include/wlr/session.h
+++ b/include/wlr/session.h
@@ -9,6 +9,10 @@ struct session_impl;
 
 struct wlr_session {
 	const struct session_impl *impl;
+	/*
+	 * Signal for when the session becomes active/inactive.
+	 * It's called when we swap virtual terminal.
+	 */
 	struct wl_signal session_signal;
 	bool active;
 
@@ -17,10 +21,45 @@ struct wlr_session {
 	char seat[8];
 };
 
+/*
+ * Opens a session, taking control of the current virtual terminal.
+ * This should not be called if another program is already in control
+ * of the terminal (Xorg, another Wayland compositor, etc.).
+ *
+ * If logind support is not enabled, you must have CAP_SYS_ADMIN or be root.
+ * It is safe to drop priviledges after this is called.
+ *
+ * Returns NULL on error.
+ */
 struct wlr_session *wlr_session_start(struct wl_display *disp);
+
+/*
+ * Closes a previously opened session and restores the virtual terminal.
+ * You should call wlr_session_close_file on each files you opened
+ * with wlr_session_open_file before you call this.
+ */
 void wlr_session_finish(struct wlr_session *session);
+
+/*
+ * Opens the file at path.
+ * This can only be used to open DRM or evdev (input) devices.
+ *
+ * When the session becomes inactive:
+ * - DRM files lose their DRM master status
+ * - evdev files become invalid and should be closed
+ *
+ * Returns -errno on error.
+ */
 int wlr_session_open_file(struct wlr_session *session, const char *path);
+
+/*
+ * Closes a file previously opened with wlr_session_open_file.
+ */
 void wlr_session_close_file(struct wlr_session *session, int fd);
+
+/*
+ * Changes the virtual terminal.
+ */
 bool wlr_session_change_vt(struct wlr_session *session, unsigned vt);
 
 #endif

--- a/include/wlr/session.h
+++ b/include/wlr/session.h
@@ -9,16 +9,18 @@ struct session_impl;
 
 struct wlr_session {
 	const struct session_impl *impl;
-
-	bool active;
 	struct wl_signal session_signal;
+	bool active;
+
+	int drm_fd;
+	unsigned vtnr;
+	char seat[8];
 };
 
 struct wlr_session *wlr_session_start(struct wl_display *disp);
 void wlr_session_finish(struct wlr_session *session);
-int wlr_session_open_file(struct wlr_session *restrict session,
-		const char *restrict path);
+int wlr_session_open_file(struct wlr_session *session, const char *path);
 void wlr_session_close_file(struct wlr_session *session, int fd);
-bool wlr_session_change_vt(struct wlr_session *session, int vt);
+bool wlr_session_change_vt(struct wlr_session *session, unsigned vt);
 
 #endif

--- a/include/wlr/session/interface.h
+++ b/include/wlr/session/interface.h
@@ -6,10 +6,9 @@
 struct session_impl {
 	struct wlr_session *(*start)(struct wl_display *disp);
 	void (*finish)(struct wlr_session *session);
-	int (*open)(struct wlr_session *restrict session,
-			const char *restrict path);
+	int (*open)(struct wlr_session *session, const char *path);
 	void (*close)(struct wlr_session *session, int fd);
-	bool (*change_vt)(struct wlr_session *session, int vt);
+	bool (*change_vt)(struct wlr_session *session, unsigned vt);
 };
 
 #endif

--- a/session/CMakeLists.txt
+++ b/session/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(
 set(sources
     session.c
     direct.c
+    direct-ipc.c
 )
 
 set(libs

--- a/session/CMakeLists.txt
+++ b/session/CMakeLists.txt
@@ -1,7 +1,6 @@
 include_directories(
     ${WAYLAND_INCLUDE_DIR}
     ${DRM_INCLUDE_DIRS}
-    ${Libcap_INCLUDE_DIRS}
 )
 
 set(sources
@@ -12,7 +11,6 @@ set(sources
 set(libs
     wlr-util
     ${WAYLAND_LIBRARIES}
-    ${Libcap_LIBRARIES}
 )
 
 if (SYSTEMD_FOUND)
@@ -22,6 +20,14 @@ if (SYSTEMD_FOUND)
     add_definitions(-DHAS_SYSTEMD)
     list(APPEND sources logind.c)
     list(APPEND libs ${SYSTEMD_LIBRARIES})
+endif ()
+
+if (Libcap_FOUND)
+    add_definitions(${Libcap_DEFINITIONS})
+    include_directories(${Libcap_INCLUDE_DIRS})
+
+    add_definitions(-DHAS_LIBCAP)
+    list(APPEND libs ${Libcap_LIBRARIES})
 endif ()
 
 add_library(wlr-session ${sources})

--- a/session/CMakeLists.txt
+++ b/session/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(
-	${WAYLAND_INCLUDE_DIR}
+    ${WAYLAND_INCLUDE_DIR}
+    ${DRM_INCLUDE_DIRS}
+    ${Libcap_INCLUDE_DIRS}
 )
 
 set(sources
@@ -10,6 +12,7 @@ set(sources
 set(libs
     wlr-util
     ${WAYLAND_LIBRARIES}
+    ${Libcap_LIBRARIES}
 )
 
 if (SYSTEMD_FOUND)

--- a/session/direct-ipc.c
+++ b/session/direct-ipc.c
@@ -1,0 +1,241 @@
+#define _POSIX_C_SOURCE 200809L
+#include <errno.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/sysmacros.h>
+#include <sys/wait.h>
+#include <xf86drm.h>
+#include <linux/major.h>
+#include <wlr/util/log.h>
+#include "session/direct-ipc.h"
+
+enum { DRM_MAJOR = 226 };
+
+#ifdef HAS_LIBCAP
+#include <sys/capability.h>
+
+static bool have_permissions(void) {
+	cap_t cap = cap_get_proc();
+	cap_flag_value_t val;
+
+	if (!cap || cap_get_flag(cap, CAP_SYS_ADMIN, CAP_PERMITTED, &val) || val != CAP_SET) {
+		wlr_log(L_ERROR, "Do not have CAP_SYS_ADMIN; cannot become DRM master");
+		cap_free(cap);
+		return false;
+	}
+
+	cap_free(cap);
+	return true;
+}
+#else
+static bool have_permissions(void) {
+	if (geteuid() != 0) {
+		wlr_log(L_ERROR, "Do not have root privileges; cannot become DRM master");
+		return false;
+	}
+
+	return true;
+}
+#endif
+
+static void send_msg(int sock, int fd, void *buf, size_t buf_len) {
+	char control[CMSG_SPACE(sizeof(fd))] = {0};
+	struct iovec iovec = { .iov_base = buf, .iov_len = buf_len };
+	struct msghdr msghdr = {0};
+
+	if (buf) {
+		msghdr.msg_iov = &iovec;
+		msghdr.msg_iovlen = 1;
+	}
+
+	if (fd >= 0) {
+		msghdr.msg_control = &control;
+		msghdr.msg_controllen = sizeof(control);
+
+		struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msghdr);
+		*cmsg = (struct cmsghdr) {
+			.cmsg_level = SOL_SOCKET,
+			.cmsg_type = SCM_RIGHTS,
+			.cmsg_len = CMSG_LEN(sizeof(fd)),
+		};
+		*(int *)CMSG_DATA(cmsg) = fd;
+	}
+
+	ssize_t ret;
+	do {
+		ret = sendmsg(sock, &msghdr, 0);
+	} while (ret < 0 && errno == EINTR);
+}
+
+static ssize_t recv_msg(int sock, int *fd_out, void *buf, size_t buf_len) {
+	char control[CMSG_SPACE(sizeof(*fd_out))] = {0};
+	struct iovec iovec = { .iov_base = buf, .iov_len = buf_len };
+	struct msghdr msghdr = {0};
+
+	if (buf) {
+		msghdr.msg_iov = &iovec;
+		msghdr.msg_iovlen = 1;
+	}
+
+	if (fd_out) {
+		msghdr.msg_control = &control;
+		msghdr.msg_controllen = sizeof(control);
+	}
+
+	ssize_t ret;
+	do {
+		ret = recvmsg(sock, &msghdr, MSG_CMSG_CLOEXEC);
+	} while (ret < 0 && errno == EINTR);
+
+	if (fd_out) {
+		struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msghdr);
+		*fd_out = cmsg ? *(int *)CMSG_DATA(cmsg) : -1;
+	}
+
+	return ret;
+}
+
+enum msg_type {
+	MSG_OPEN,
+	MSG_SETMASTER,
+	MSG_DROPMASTER,
+	MSG_END,
+};
+
+struct msg {
+	enum msg_type type;
+	char path[256];
+};
+
+static void communicate(int sock) {
+	struct msg msg;
+	int drm_fd = -1;
+	bool running = true;
+
+	while (running && recv_msg(sock, NULL, &msg, sizeof(msg)) >= 0) {
+		switch (msg.type) {
+		case MSG_OPEN:
+			errno = 0;
+
+			// These are the same flags that logind opens files with
+			int fd = open(msg.path, O_RDWR|O_CLOEXEC|O_NOCTTY|O_NONBLOCK);
+			int ret = errno;
+			if (fd == -1) {
+				goto error;
+			}
+
+			struct stat st;
+			if (fstat(fd, &st) < 0) {
+				ret = errno;
+				goto error;
+			}
+
+			uint32_t maj = major(st.st_rdev);
+			if (maj != INPUT_MAJOR && maj != DRM_MAJOR) {
+				ret = ENOTSUP;
+				goto error;
+			}
+
+			if (maj == DRM_MAJOR) {
+				if (drmSetMaster(fd)) {
+					ret = errno;
+				} else {
+					drm_fd = fd;
+				}
+			}
+error:
+			send_msg(sock, ret ? -1 : fd, &ret, sizeof(ret));
+
+			if (fd != drm_fd) {
+				close(fd);
+			}
+
+			break;
+
+		case MSG_SETMASTER:
+			drmSetMaster(drm_fd);
+			send_msg(sock, -1, NULL, 0);
+			break;
+
+		case MSG_DROPMASTER:
+			drmDropMaster(drm_fd);
+			send_msg(sock, -1, NULL, 0);
+			break;
+
+		case MSG_END:
+			running = false;
+			send_msg(sock, -1, NULL, 0);
+			break;
+		}
+	}
+
+	close(drm_fd);
+	close(sock);
+}
+
+int direct_ipc_open(int sock, const char *path) {
+	struct msg msg = { .type = MSG_OPEN };
+	snprintf(msg.path, sizeof(msg.path), "%s", path);
+
+	send_msg(sock, -1, &msg, sizeof(msg));
+
+	int fd, err;
+	recv_msg(sock, &fd, &err, sizeof(err));
+
+	return err ? -err : fd;
+}
+
+void direct_ipc_setmaster(int sock) {
+	struct msg msg = { .type = MSG_SETMASTER };
+
+	send_msg(sock, -1, &msg, sizeof(msg));
+	recv_msg(sock, NULL, NULL, 0);
+}
+
+void direct_ipc_dropmaster(int sock) {
+	struct msg msg = { .type = MSG_DROPMASTER };
+
+	send_msg(sock, -1, &msg, sizeof(msg));
+	recv_msg(sock, NULL, NULL, 0);
+}
+
+void direct_ipc_finish(int sock, pid_t pid) {
+	struct msg msg = { .type = MSG_END };
+
+	send_msg(sock, -1, &msg, sizeof(msg));
+	recv_msg(sock, NULL, NULL, 0);
+
+	waitpid(pid, NULL, 0);
+}
+
+int direct_ipc_start(pid_t *pid_out) {
+	if (!have_permissions()) {
+		return -1;
+	}
+
+	int sock[2];
+	if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sock) < 0) {
+		wlr_log_errno(L_ERROR, "Failed to create socket pair");
+		return -1;
+	}
+
+	pid_t pid = fork();
+	if (pid < 0) {
+		wlr_log_errno(L_ERROR, "Fork failed");
+		close(sock[0]);
+		close(sock[1]);
+		return -1;
+	} else if (pid == 0) {
+		close(sock[0]);
+		communicate(sock[1]);
+		_Exit(0);
+	}
+
+	close(sock[1]);
+	*pid_out = pid;
+	return sock[0];
+}

--- a/session/direct.c
+++ b/session/direct.c
@@ -65,7 +65,7 @@ static void direct_session_close(struct wlr_session *base, int fd) {
 	}
 
 	if (major(st.st_rdev) == DRM_MAJOR) {
-		direct_ipc_dropmaster(session->sock);
+		direct_ipc_dropmaster(session->sock, session->base.drm_fd);
 		session->base.drm_fd = -1;
 	} else if (major(st.st_rdev) == INPUT_MAJOR) {
 		ioctl(fd, EVIOCREVOKE, 0);
@@ -109,11 +109,11 @@ static int vt_handler(int signo, void *data) {
 	if (session->base.active) {
 		session->base.active = false;
 		wl_signal_emit(&session->base.session_signal, session);
-		direct_ipc_dropmaster(session->sock);
+		direct_ipc_dropmaster(session->sock, session->base.drm_fd);
 		ioctl(session->tty_fd, VT_RELDISP, 1);
 	} else {
 		ioctl(session->tty_fd, VT_RELDISP, VT_ACKACQ);
-		direct_ipc_setmaster(session->sock);
+		direct_ipc_setmaster(session->sock, session->base.drm_fd);
 		session->base.active = true;
 		wl_signal_emit(&session->base.session_signal, session);
 	}

--- a/session/direct.c
+++ b/session/direct.c
@@ -23,10 +23,6 @@
 #include <sys/capability.h>
 #endif
 
-#ifndef KDSKBMUTE
-#define KDSKBMUTE	0x4B51
-#endif
-
 enum { DRM_MAJOR = 226 };
 
 const struct session_impl session_direct;
@@ -147,9 +143,7 @@ static void direct_session_finish(struct wlr_session *base) {
 		.mode = VT_AUTO,
 	};
 
-	if (ioctl(session->tty_fd, KDSKBMUTE, 0)) {
-		ioctl(session->tty_fd, KDSKBMODE, session->kb_mode);
-	}
+	ioctl(session->tty_fd, KDSKBMODE, session->kb_mode);
 	ioctl(session->tty_fd, KDSETMODE, KD_TEXT);
 	ioctl(session->tty_fd, VT_SETMODE, &mode);
 
@@ -214,8 +208,7 @@ static bool setup_tty(struct direct_session *session, struct wl_display *display
 		goto error;
 	}
 
-	if (ioctl(session->tty_fd, KDSKBMUTE, 1) &&
-			ioctl(session->tty_fd, KDSKBMODE, K_OFF)) {
+	if (ioctl(session->tty_fd, KDSKBMODE, K_OFF)) {
 		wlr_log_errno(L_ERROR, "Failed to set keyboard mode");
 		goto error;
 	}

--- a/session/direct.c
+++ b/session/direct.c
@@ -2,7 +2,6 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdbool.h>
 #include <string.h>
 #include <fcntl.h>
@@ -11,7 +10,6 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
-#include <sys/capability.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
 #include <linux/kd.h>
@@ -21,6 +19,9 @@
 #include <xf86drm.h>
 #include <wlr/session/interface.h>
 #include <wlr/util/log.h>
+#ifdef HAS_LIBCAP
+#include <sys/capability.h>
+#endif
 
 #ifndef KDSKBMUTE
 #define KDSKBMUTE	0x4B51

--- a/session/direct.c
+++ b/session/direct.c
@@ -5,34 +5,172 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/capability.h>
+#include <linux/kd.h>
+#include <linux/major.h>
+#include <linux/vt.h>
 #include <wayland-server.h>
+#include <xf86drm.h>
 #include <wlr/session/interface.h>
 #include <wlr/util/log.h>
+
+#ifndef KDSKBMUTE
+#define KDSKBMUTE	0x4B51
+#endif
+
+enum { DRM_MAJOR = 226 };
 
 const struct session_impl session_direct;
 
 struct direct_session {
 	struct wlr_session base;
+	int tty_fd;
+	int drm_fd;
+	int kb_mode;
+
+	struct wl_event_source *vt_source;
 };
 
 static int direct_session_open(struct wlr_session *restrict base,
-	const char *restrict path) {
-	return open(path, O_RDWR | O_CLOEXEC);
+		const char *restrict path) {
+	struct direct_session *session = wl_container_of(base, session, base);
+	int fd = open(path, O_RDWR | O_CLOEXEC | O_NOCTTY | O_NONBLOCK);
+	if (fd == -1) {
+		wlr_log_errno(L_ERROR, "%s", path);
+		return -errno;
+	}
+
+	struct stat st;
+	if (fstat(fd, &st) == 0 && major(st.st_rdev) == DRM_MAJOR) {
+		session->drm_fd = fd;
+		drmSetMaster(fd);
+	}
+
+	return fd;
 }
 
 static void direct_session_close(struct wlr_session *base, int fd) {
+	struct direct_session *session = wl_container_of(base, session, base);
+
+	if (fd == session->drm_fd) {
+		drmDropMaster(fd);
+		session->drm_fd = -1;
+	}
+
 	close(fd);
 }
 
 static bool direct_change_vt(struct wlr_session *base, int vt) {
-	// TODO
-	return false;
+	struct direct_session *session = wl_container_of(base, session, base);
+	return ioctl(session->tty_fd, VT_ACTIVATE, vt) == 0;
 }
 
 static void direct_session_finish(struct wlr_session *base) {
 	struct direct_session *session = wl_container_of(base, session, base);
+	struct vt_mode mode = {
+		.mode = VT_AUTO,
+	};
 
+	if (ioctl(session->tty_fd, KDSKBMUTE, 0)) {
+		ioctl(session->tty_fd, KDSKBMODE, session->kb_mode);
+	}
+	ioctl(session->tty_fd, KDSETMODE, KD_TEXT);
+	ioctl(session->tty_fd, VT_SETMODE, &mode);
+
+	wl_event_source_remove(session->vt_source);
+	close(session->tty_fd);
 	free(session);
+}
+
+static int vt_handler(int signo, void *data) {
+	struct direct_session *session = data;
+
+	if (session->base.active) {
+		session->base.active = false;
+		wl_signal_emit(&session->base.session_signal, session);
+		drmDropMaster(session->drm_fd);
+		ioctl(session->tty_fd, VT_RELDISP, 1);
+	} else {
+		ioctl(session->tty_fd, VT_RELDISP, VT_ACKACQ);
+		drmSetMaster(session->drm_fd);
+		session->base.active = true;
+		wl_signal_emit(&session->base.session_signal, session);
+	}
+
+	return 1;
+}
+
+static bool setup_tty(struct direct_session *session, struct wl_display *display) {
+	session->tty_fd = dup(STDIN_FILENO);
+
+	struct stat st;
+	if (fstat(session->tty_fd, &st) == -1 || major(st.st_rdev) != TTY_MAJOR ||
+			minor(st.st_rdev) == 0) {
+		wlr_log(L_ERROR, "Not running from a virtual terminal");
+		goto error;
+	}
+
+	int ret;
+
+	int kd_mode;
+	ret = ioctl(session->tty_fd, KDGETMODE, &kd_mode);
+	if (ret) {
+		wlr_log_errno(L_ERROR, "Failed to get tty mode");
+		goto error;
+	}
+
+	if (kd_mode != KD_TEXT) {
+		wlr_log(L_ERROR,
+			"tty already in graphics mode; is another display server running?");
+		goto error;
+	}
+
+	ioctl(session->tty_fd, VT_ACTIVATE, minor(st.st_rdev));
+	ioctl(session->tty_fd, VT_WAITACTIVE, minor(st.st_rdev));
+
+	if (ioctl(session->tty_fd, KDGKBMODE, &session->kb_mode)) {
+		wlr_log_errno(L_ERROR, "Failed to read keyboard mode");
+		goto error;
+	}
+
+	if (ioctl(session->tty_fd, KDSKBMUTE, 1) &&
+			ioctl(session->tty_fd, KDSKBMODE, K_OFF)) {
+		wlr_log_errno(L_ERROR, "Failed to set keyboard mode");
+		goto error;
+	}
+
+	if (ioctl(session->tty_fd, KDSETMODE, KD_GRAPHICS)) {
+		wlr_log_errno(L_ERROR, "Failed to get graphics mode on tty");
+		goto error;
+	}
+
+	struct vt_mode mode = {
+		.mode = VT_PROCESS,
+		.relsig = SIGUSR1,
+		.acqsig = SIGUSR1,
+	};
+
+	if (ioctl(session->tty_fd, VT_SETMODE, &mode) < 0) {
+		wlr_log(L_ERROR, "Failed to take control of tty");
+		goto error;
+	}
+
+	struct wl_event_loop *loop = wl_display_get_event_loop(display);
+	session->vt_source = wl_event_loop_add_signal(loop, SIGUSR1,
+		vt_handler, session);
+	if (!session->vt_source) {
+		goto error;
+	}
+
+	return true;
+
+error:
+	close(session->tty_fd);
+	return false;
 }
 
 static struct wlr_session *direct_session_start(struct wl_display *disp) {
@@ -42,12 +180,31 @@ static struct wlr_session *direct_session_start(struct wl_display *disp) {
 		return NULL;
 	}
 
+	cap_t cap = cap_get_proc();
+	cap_flag_value_t val;
+
+	if (!cap || cap_get_flag(cap, CAP_SYS_ADMIN, CAP_PERMITTED, &val) || val != CAP_SET) {
+		wlr_log(L_ERROR, "Do not have CAP_SYS_ADMIN; cannot become DRM master");
+		cap_free(cap);
+		goto error_session;
+	}
+
+	cap_free(cap);
+
+	if (!setup_tty(session, disp)) {
+		goto error_session;
+	}
+
 	wlr_log(L_INFO, "Successfully loaded direct session");
 
 	session->base.impl = &session_direct;
 	session->base.active = true;
 	wl_signal_init(&session->base.session_signal);
 	return &session->base;
+
+error_session:
+	free(session);
+	return NULL;
 }
 
 const struct session_impl session_direct = {

--- a/session/session.c
+++ b/session/session.c
@@ -33,9 +33,7 @@ void wlr_session_finish(struct wlr_session *session) {
 	session->impl->finish(session);
 };
 
-int wlr_session_open_file(struct wlr_session *restrict session,
-	const char *restrict path) {
-
+int wlr_session_open_file(struct wlr_session *session, const char *path) {
 	return session->impl->open(session, path);
 }
 
@@ -43,6 +41,6 @@ void wlr_session_close_file(struct wlr_session *session, int fd) {
 	session->impl->close(session, fd);
 }
 
-bool wlr_session_change_vt(struct wlr_session *session, int vt) {
+bool wlr_session_change_vt(struct wlr_session *session, unsigned vt) {
 	return session->impl->change_vt(session, vt);
 }


### PR DESCRIPTION
Updated the 'direct' backend to now fork, so that the child (with privileges) can call drmSetMaster/drmDropMaster. It's up to the library user to drop any extra privileges after they initialise wlroots. It also initialises the TTY properly and handles VT switching.

Libcap was added as an optional dependency, so we can have processes with CAP_SYS_ADMIN instead of needing to seteuid as root. If logind is being used, there is no need to do this.

There are a couple of outstanding issues:
- Just like the logind code, it still makes a lot of assumptions about there being a single GPU per session.
- It's very Linux specific. I know that WLC had some things to get their TTY code to work with FreeBSD, but I'm not going to blindly copy that code if I can't test it. Someone else can take a look at fixing this if they want to.
- The examples haven't been updated to use setcap/seteuid. You must do it manually.

If you're going to run this code, make sure you have permissions for /dev/input/event* (be part of the input group) or run as root, otherwise you'll run into #24.