### PR TITLE
Add null session

### DIFF
--- a/session/null.c
+++ b/session/null.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <wayland-server.h>
+#include <wayland-util.h>
+#include <wlr/session/interface.h>
+#include <wlr/util/log.h>
+
+const struct session_impl session_null;
+
+static bool null_session_change_vt(struct wlr_session *session, unsigned vt) {
+	return false;
+}
+
+static void null_session_close(struct wlr_session *session, int fd) {
+	// Calling this function is a programming error
+	wlr_log(L_ERROR, "Invalid call to wlr_session_close with null session");
+	exit(1);
+}
+
+static int null_session_open(struct wlr_session *session, const char *path) {
+	// Calling this function is a programming error
+	wlr_log(L_ERROR, "Invalid call to wlr_session_open with null session");
+	exit(1);
+}
+
+static void null_session_finish(struct wlr_session *session) {
+	free(session);
+}
+
+static struct wlr_session *null_session_start(struct wl_display *disp) {
+	if (!getenv("WAYLAND_DISPLAY") && !getenv("_WAYLAND_DISPLAY") && !getenv("DISPLAY")) {
+		return NULL;
+	}
+
+	struct wlr_session *session = calloc(1, sizeof(*session));
+	if (!session) {
+		wlr_log_errno(L_ERROR, "Allocation failed");
+		return NULL;
+	}
+
+	const char *seat = getenv("XDG_SEAT");
+	if (!seat) {
+		seat = "seat0";
+	}
+
+	wlr_log(L_INFO, "Successfully loaded null session");
+
+	snprintf(session->seat, sizeof(session->seat), "%s", seat);
+	session->drm_fd = -1;
+	session->impl = &session_null;
+	session->active = true;
+	wl_signal_init(&session->session_signal);
+	return session;
+}
+
+const struct session_impl session_null = {
+	.start = null_session_start,
+	.finish = null_session_finish,
+	.open = null_session_open,
+	.close = null_session_close,
+	.change_vt = null_session_change_vt,
+};

--- a/session/session.c
+++ b/session/session.c
@@ -4,10 +4,12 @@
 #include <wlr/session/interface.h>
 #include <wlr/util/log.h>
 
+extern const struct session_impl session_null;
 extern const struct session_impl session_logind;
 extern const struct session_impl session_direct;
 
 static const struct session_impl *impls[] = {
+	&session_null,
 #ifdef HAS_SYSTEMD
 	&session_logind,
 #endif
@@ -30,6 +32,10 @@ struct wlr_session *wlr_session_start(struct wl_display *disp) {
 }
 
 void wlr_session_finish(struct wlr_session *session) {
+	if (!session) {
+		return;
+	}
+
 	session->impl->finish(session);
 };
 
@@ -42,5 +48,9 @@ void wlr_session_close_file(struct wlr_session *session, int fd) {
 }
 
 bool wlr_session_change_vt(struct wlr_session *session, unsigned vt) {
+	if (!session) {
+		return false;
+	}
+
 	return session->impl->change_vt(session, vt);
 }


### PR DESCRIPTION
This is just a session backend which does nothing.
It's so when we're using a wayland/xorg/whatever (anything that isn't DRM, really) backend, the user can be given this session and not worry about checking what backend is actually being used.

This fixes a bug where closing one of the examples using the wayland backend would absolutely destroy your session (massive visual glitches, unable to change VT), and forces you to restart your computer. This happened to me when using an example under weston under X.

This PR doesn't add "session/null.c" to the build system. I'll add it when/if the meson PR is accepted.

Instead of doing this sort of patchwork fix, we might want to consider whether we want wlr_session to be part of the public API. Maybe all of the session stuff could be handled in `wlr_backend_autocreate`, so we don't accidentally try to open a logind/direct session when we're not using DRM.