### PR TITLE
Build on travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+arch:
+  packages:
+    - cmake
+    - wayland
+    - wayland-protocols
+    - mesa
+    - libinput
+    - libxkbcommon
+    - libcap
+  script:
+    - "cmake -DCMAKE_BUILD_TYPE=Release ."
+    - "make"
+
+script:
+  - "curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wlroots
+# wlroots [![](https://api.travis-ci.org/SirCmpwn/wlroots.svg)](https://travis-ci.org/SirCmpwn/wlroots)
 
 Pluggable, composable modules for building a Wayland compositor.
 


### PR DESCRIPTION
Add `.travis.yml` for building on travis via [arch-travis](https://github.com/mikkeloscar/arch-travis).

Also adds build badge to README.md.

@SirCmpwn you need to enable the repository in travis for this to work.

Note: The build is currently failing due to an unused variable: https://travis-ci.org/mikkeloscar/wlroots/jobs/252789478