### PR TITLE
bugfix: fix cursor software rendering fallback

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -206,7 +206,7 @@ bool wlr_output_set_cursor(struct wlr_output *output,
 		output->cursor.texture = wlr_render_surface_init(output->cursor.renderer);
 	}
 
-	wlr_surface_attach_pixels(output->cursor.texture, GL_RGBA,
+	wlr_surface_attach_pixels(output->cursor.texture, WL_SHM_FORMAT_XBGR8888,
 		stride, width, height, buf);
 
 	return true;


### PR DESCRIPTION
wlr_surface_attach_pixels() expects a wl_shm_format but a GL format was
given. This caused a bug where software rendering of the cursor would
fail when no pixel format can be found.