### PR TITLE
bugfix: add null check on output gbm on pageflip

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -631,7 +631,7 @@ static void page_flip_handler(int fd, unsigned seq,
 	struct wlr_backend_state *state =
 		wl_container_of(output->renderer, state, renderer);
 
-	if (output->bo[1]) {
+	if (output->gbm && output->bo[1]) {
 		gbm_surface_release_buffer(output->gbm, output->bo[1]);
 		output->bo[1] = NULL;
 	}


### PR DESCRIPTION
The gbm for the output might be null for the pageflip in the case that
the output has been disconnected. The gbm might be set to null by
wlr_drm_output_cleanup() in this case.

If the output is cleaned up before the pageflip, then a double free
will crash the compositor on the call to gbm_surface_release_buffer()
in the pageflip handler. The outputs buffer object bo[1] will point to
invalid memory.