### PR TITLE
Use correct pixel format enum in touch example

### DIFF
--- a/examples/touch.c
+++ b/examples/touch.c
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
 
 	state.renderer = wlr_gles2_renderer_init();
 	state.cat_texture = wlr_render_surface_init(state.renderer);
-	wlr_surface_attach_pixels(state.cat_texture, GL_RGBA,
+	wlr_surface_attach_pixels(state.cat_texture, WL_SHM_FORMAT_ARGB8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);
 
 	compositor_run(&compositor);


### PR DESCRIPTION
Fix a call to `wlr_surface_attach_pixels()` in the main method of the touch
example to use the correct enum for this method (wayland instead of gl).