### PR TITLE
Add surface interface stubs in compositor example

### DIFF
--- a/examples/compositor.h
+++ b/examples/compositor.h
@@ -1,14 +1,16 @@
 #ifndef _EXAMPLE_COMPOSITOR_H
 #define _EXAMPLE_COMPOSITOR_H
 #include <wayland-server.h>
+#include <wlr/render.h>
 
 struct wl_compositor_state {
 	struct wl_global *wl_global;
 	struct wl_list wl_resources;
+	struct wlr_renderer *renderer;
 };
 
 void wl_compositor_init(struct wl_display *display,
-		struct wl_compositor_state *state);
+		struct wl_compositor_state *state, struct wlr_renderer *renderer);
 
 struct wl_shell_state {
 	struct wl_global *wl_global;

--- a/examples/compositor.h
+++ b/examples/compositor.h
@@ -8,6 +8,7 @@ struct wl_compositor_state {
 	struct wl_list wl_resources;
 	struct wlr_renderer *renderer;
 	struct wl_list surfaces;
+	struct wl_listener destroy_surface_listener;
 };
 
 void wl_compositor_init(struct wl_display *display,

--- a/examples/compositor.h
+++ b/examples/compositor.h
@@ -7,6 +7,7 @@ struct wl_compositor_state {
 	struct wl_global *wl_global;
 	struct wl_list wl_resources;
 	struct wlr_renderer *renderer;
+	struct wl_list surfaces;
 };
 
 void wl_compositor_init(struct wl_display *display,

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -11,6 +11,7 @@
 #include <wlr/render/gles2.h>
 #include <wlr/types/wlr_output.h>
 #include <xkbcommon/xkbcommon.h>
+#include <wlr/util/log.h>
 #include "shared.h"
 #include "compositor.h"
 
@@ -42,7 +43,7 @@ int main() {
 
 	state.renderer = wlr_gles2_renderer_init();
 	wl_display_init_shm(compositor.display);
-	wl_compositor_init(compositor.display, &state.compositor);
+	wl_compositor_init(compositor.display, &state.compositor, state.renderer);
 	wl_shell_init(compositor.display, &state.shell);
 
 	compositor_run(&compositor);

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -28,7 +28,18 @@ void handle_output_frame(struct output_state *output, struct timespec *ts) {
 
 	wlr_output_make_current(wlr_output);
 	wlr_renderer_begin(sample->renderer, wlr_output);
-	// TODO: render surfaces
+
+	struct wl_resource *_res;
+	float matrix[16];
+	wl_list_for_each(_res, &sample->compositor.surfaces, link) {
+		struct wlr_surface *surface = wl_resource_get_user_data(_res);
+		if (surface->valid) {
+			wlr_surface_get_matrix(surface, &matrix,
+					&wlr_output->transform_matrix, 200, 200);
+			wlr_render_with_matrix(sample->renderer, surface, &matrix);
+		}
+	}
+
 	wlr_renderer_end(sample->renderer);
 	wlr_output_swap_buffers(wlr_output);
 }

--- a/examples/compositor/wl_compositor.c
+++ b/examples/compositor/wl_compositor.c
@@ -3,13 +3,95 @@
 #include <wlr/util/log.h>
 #include "compositor.h"
 
+static void surface_destroy(struct wl_client *client, struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static void surface_attach(struct wl_client *client,
+		struct wl_resource *resource,
+		struct wl_resource *buffer_resource, int32_t sx, int32_t sy) {
+	wlr_log(L_DEBUG, "TODO: surface attach");
+}
+
+static void surface_damage(struct wl_client *client,
+		struct wl_resource *resource,
+		int32_t x, int32_t y, int32_t width, int32_t height) {
+	wlr_log(L_DEBUG, "TODO: surface damage");
+}
+
+static void surface_frame(struct wl_client *client,
+		struct wl_resource *resource, uint32_t callback) {
+	wlr_log(L_DEBUG, "TODO: surface frame");
+}
+
+static void surface_set_opaque_region(struct wl_client *client,
+		struct wl_resource *resource,
+		struct wl_resource *region_resource) {
+	wlr_log(L_DEBUG, "TODO: surface opaque region");
+}
+
+static void surface_set_input_region(struct wl_client *client,
+		struct wl_resource *resource,
+		struct wl_resource *region_resource) {
+
+	wlr_log(L_DEBUG, "TODO: surface input region");
+}
+
+static void surface_commit(struct wl_client *client,
+		struct wl_resource *resource) {
+	wlr_log(L_DEBUG, "TODO: surface surface commit");
+}
+
+static void surface_set_buffer_transform(struct wl_client *client,
+		struct wl_resource *resource, int transform) {
+	wlr_log(L_DEBUG, "TODO: surface surface buffer transform");
+}
+
+static void surface_set_buffer_scale(struct wl_client *client,
+		struct wl_resource *resource,
+		int32_t scale) {
+	wlr_log(L_DEBUG, "TODO: surface set buffer scale");
+}
+
+
+static void surface_damage_buffer(struct wl_client *client,
+		struct wl_resource *resource,
+		int32_t x, int32_t y, int32_t width,
+		int32_t height) {
+	wlr_log(L_DEBUG, "TODO: surface damage buffer");
+}
+
+struct wl_surface_interface surface_interface = {
+	surface_destroy,
+	surface_attach,
+	surface_damage,
+	surface_frame,
+	surface_set_opaque_region,
+	surface_set_input_region,
+	surface_commit,
+	surface_set_buffer_transform,
+	surface_set_buffer_scale,
+	surface_damage_buffer
+};
+
+static void destroy_surface(struct wl_resource *resource) {
+	wlr_log(L_DEBUG, "TODO: destroy surface");
+}
+
 static void wl_compositor_create_surface(struct wl_client *client,
-			   struct wl_resource *resource, uint32_t id) {
-	wlr_log(L_DEBUG, "TODO: implement create_surface");
+		struct wl_resource *resource, uint32_t id) {
+	struct wl_compositor_state *state = wl_resource_get_user_data(resource);
+	struct wl_resource *surface_resource = wl_resource_create(client,
+			&wl_surface_interface, wl_resource_get_version(resource), id);
+	struct wlr_surface *surface = wlr_render_surface_init(state->renderer);
+	wl_resource_set_implementation(surface_resource, &surface_interface,
+			surface, destroy_surface);
+	wl_resource_set_user_data(surface_resource, surface);
+
 }
 
 static void wl_compositor_create_region(struct wl_client *client,
-			  struct wl_resource *resource, uint32_t id) {
+		struct wl_resource *resource, uint32_t id) {
 	wlr_log(L_DEBUG, "TODO: implement create_region");
 }
 
@@ -47,9 +129,10 @@ static void wl_compositor_bind(struct wl_client *wl_client, void *_state,
 }
 
 void wl_compositor_init(struct wl_display *display,
-		struct wl_compositor_state *state) {
+		struct wl_compositor_state *state, struct wlr_renderer *renderer) {
 	struct wl_global *wl_global = wl_global_create(display,
 		&wl_compositor_interface, 4, state, wl_compositor_bind);
 	state->wl_global = wl_global;
+	state->renderer = renderer;
 	wl_list_init(&state->wl_resources);
 }

--- a/examples/compositor/wl_compositor.c
+++ b/examples/compositor/wl_compositor.c
@@ -10,7 +10,10 @@ static void surface_destroy(struct wl_client *client, struct wl_resource *resour
 static void surface_attach(struct wl_client *client,
 		struct wl_resource *resource,
 		struct wl_resource *buffer_resource, int32_t sx, int32_t sy) {
-	wlr_log(L_DEBUG, "TODO: surface attach");
+	struct wlr_surface *surface = wl_resource_get_user_data(resource);
+	struct wl_shm_buffer *buffer = wl_shm_buffer_get(buffer_resource);
+	uint32_t format = wl_shm_buffer_get_format(buffer);
+	wlr_surface_attach_shm(surface, format, buffer);
 }
 
 static void surface_damage(struct wl_client *client,
@@ -87,7 +90,7 @@ static void wl_compositor_create_surface(struct wl_client *client,
 	wl_resource_set_implementation(surface_resource, &surface_interface,
 			surface, destroy_surface);
 	wl_resource_set_user_data(surface_resource, surface);
-
+	wl_list_insert(&state->surfaces, wl_resource_get_link(surface_resource));
 }
 
 static void wl_compositor_create_region(struct wl_client *client,
@@ -135,4 +138,5 @@ void wl_compositor_init(struct wl_display *display,
 	state->wl_global = wl_global;
 	state->renderer = renderer;
 	wl_list_init(&state->wl_resources);
+	wl_list_init(&state->surfaces);
 }

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -57,6 +57,8 @@ struct wlr_surface {
 	bool valid;
 	uint32_t format;
 	int width, height;
+	struct wl_signal destroy_signal;
+	struct wl_resource *resource;
 };
 
 /**

--- a/render/gles2/surface.c
+++ b/render/gles2/surface.c
@@ -34,6 +34,35 @@ static bool gles2_surface_attach_pixels(struct wlr_surface_state *surface,
 	return true;
 }
 
+static bool gles2_surface_attach_shm(struct wlr_surface_state *surface,
+		uint32_t format, struct wl_shm_buffer *buffer) {
+	const struct pixel_format *fmt = gl_format_for_wl_format(format);
+	if (!fmt || !fmt->gl_format) {
+		wlr_log(L_ERROR, "No supported pixel format for this surface");
+		return false;
+	}
+	wl_shm_buffer_begin_access(buffer);
+	uint8_t *pixels = wl_shm_buffer_get_data(buffer);
+	int width = wl_shm_buffer_get_width(buffer);
+	int height = wl_shm_buffer_get_height(buffer);
+	int pitch = wl_shm_buffer_get_stride(buffer) / (fmt->bpp / 8);
+	surface->wlr_surface->width = width;
+	surface->wlr_surface->height = height;
+	surface->wlr_surface->format = format;
+	surface->pixel_format = fmt;
+
+	GL_CALL(glActiveTexture(GL_TEXTURE0));
+	GL_CALL(glGenTextures(1, &surface->tex_id));
+	GL_CALL(glBindTexture(GL_TEXTURE_2D, surface->tex_id));
+	GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, pitch));
+	GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, fmt->gl_format, width, height, 0,
+				fmt->gl_format, fmt->gl_type, pixels));
+
+	surface->wlr_surface->valid = true;
+	wl_shm_buffer_end_access(buffer);
+	return true;
+}
+
 static void gles2_surface_get_matrix(struct wlr_surface_state *surface,
 		float (*matrix)[16], const float (*projection)[16], int x, int y) {
 	struct wlr_surface *_surface = surface->wlr_surface;
@@ -61,7 +90,7 @@ static void gles2_surface_destroy(struct wlr_surface_state *surface) {
 
 static struct wlr_surface_impl wlr_surface_impl = {
 	.attach_pixels = gles2_surface_attach_pixels,
-	// .attach_shm = TODO
+	.attach_shm = gles2_surface_attach_shm,
 	.get_matrix = gles2_surface_get_matrix,
 	.bind = gles2_surface_bind,
 	.destroy = gles2_surface_destroy,

--- a/render/gles2/surface.c
+++ b/render/gles2/surface.c
@@ -84,6 +84,7 @@ static void gles2_surface_bind(struct wlr_surface_state *surface) {
 }
 
 static void gles2_surface_destroy(struct wlr_surface_state *surface) {
+	wl_signal_emit(&surface->wlr_surface->destroy_signal, surface->wlr_surface);
 	GL_CALL(glDeleteTextures(1, &surface->tex_id));
 	free(surface);
 }
@@ -100,5 +101,6 @@ struct wlr_surface *gles2_surface_init() {
 	struct wlr_surface_state *state = calloc(sizeof(struct wlr_surface_state), 1);
 	struct wlr_surface *surface = wlr_surface_init(state, &wlr_surface_impl);
 	state->wlr_surface = surface;
+	wl_signal_init(&surface->destroy_signal);
 	return surface;
 }


### PR DESCRIPTION
Add the wayland surface interface to the example compositor.

Implement the create_surface method to create a new wlr surface from the
wayland surface and add the interface.