### PR TITLE
Atomic modesetting

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -53,7 +53,11 @@ static void session_signal(struct wl_listener *listener, void *data) {
 		for (size_t i = 0; i < drm->outputs->length; ++i) {
 			struct wlr_output_state *output = drm->outputs->items[i];
 			wlr_drm_output_start_renderer(output);
-			wlr_drm_crtc_set_cursor(drm, output->crtc);
+
+			struct wlr_drm_plane *plane = output->crtc->cursor;
+
+			drm->iface->crtc_set_cursor(drm, output->crtc,
+				plane ? plane->cursor_bo : NULL);
 		}
 	} else {
 		wlr_log(L_INFO, "DRM fd paused");

--- a/backend/drm/drm-atomic.c
+++ b/backend/drm/drm-atomic.c
@@ -1,0 +1,176 @@
+#include <gbm.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#include <wlr/util/log.h>
+#include "backend/drm.h"
+#include "backend/drm-util.h"
+
+struct atomic {
+	drmModeAtomicReq *req;
+	int cursor;
+	bool failed;
+};
+
+static void atomic_begin(struct wlr_drm_crtc *crtc, struct atomic *atom) {
+	if (!crtc->atomic) {
+		crtc->atomic = drmModeAtomicAlloc();
+		if (!crtc->atomic) {
+			wlr_log_errno(L_ERROR, "Allocation failed");
+			atom->failed = true;
+			return;
+		}
+	}
+
+	atom->req = crtc->atomic;
+	atom->cursor = drmModeAtomicGetCursor(atom->req);
+	atom->failed = false;
+}
+
+static bool atomic_end(int drm_fd, struct atomic *atom) {
+	if (atom->failed) {
+		return false;
+	}
+
+	uint32_t flags = DRM_MODE_ATOMIC_TEST_ONLY | DRM_MODE_ATOMIC_NONBLOCK;
+
+	if (drmModeAtomicCommit(drm_fd, atom->req, flags, NULL)) {
+		wlr_log_errno(L_ERROR, "Atomic test failed");
+		drmModeAtomicSetCursor(atom->req, atom->cursor);
+		return false;
+	}
+
+	return true;
+}
+
+static bool atomic_commit(int drm_fd, struct atomic *atom, struct wlr_output_state *output,
+		uint32_t flag) {
+	if (atom->failed) {
+		return false;
+	}
+
+	uint32_t flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK | flag;
+
+	int ret = drmModeAtomicCommit(drm_fd, atom->req, flags, output);
+	if (ret) {
+		wlr_log_errno(L_ERROR, "Atomic commit failed");
+	}
+
+	drmModeAtomicSetCursor(atom->req, 0);
+
+	return !ret;
+}
+
+static inline void atomic_add(struct atomic *atom, uint32_t id, uint32_t prop, uint64_t val) {
+	if (!atom->failed && drmModeAtomicAddProperty(atom->req, id, prop, val) < 0) {
+		wlr_log_errno(L_ERROR, "Failed to add atomic DRM property");
+		atom->failed = true;
+	}
+}
+
+static void set_plane_props(struct atomic *atom, struct wlr_drm_plane *plane,
+		uint32_t crtc_id, uint32_t fb_id, bool set_crtc_xy) {
+	uint32_t id = plane->id;
+	const union wlr_drm_plane_props *props = &plane->props;
+
+	// The src_* properties are in 16.16 fixed point
+	atomic_add(atom, id, props->src_x, 0);
+	atomic_add(atom, id, props->src_y, 0);
+	atomic_add(atom, id, props->src_w, plane->width << 16);
+	atomic_add(atom, id, props->src_h, plane->height << 16);
+	atomic_add(atom, id, props->crtc_w, plane->width);
+	atomic_add(atom, id, props->crtc_h, plane->height);
+	atomic_add(atom, id, props->fb_id, fb_id);
+	atomic_add(atom, id, props->crtc_id, crtc_id);
+	if (set_crtc_xy) {
+		atomic_add(atom, id, props->crtc_x, 0);
+		atomic_add(atom, id, props->crtc_y, 0);
+	}
+}
+
+static bool atomic_crtc_pageflip(struct wlr_backend_state *drm, struct wlr_output_state *output,
+		struct wlr_drm_crtc *crtc, uint32_t fb_id, drmModeModeInfo *mode) {
+	if (mode) {
+		if (crtc->mode_id) {
+			drmModeDestroyPropertyBlob(drm->fd, crtc->mode_id);
+		}
+
+		if (drmModeCreatePropertyBlob(drm->fd, mode, sizeof(*mode), &crtc->mode_id)) {
+			wlr_log_errno(L_ERROR, "Unable to create property blob");
+			return false;
+		}
+	}
+
+	struct atomic atom;
+
+	atomic_begin(crtc, &atom);
+	atomic_add(&atom, output->connector, output->props.crtc_id, crtc->id);
+	atomic_add(&atom, crtc->id, crtc->props.mode_id, crtc->mode_id);
+	atomic_add(&atom, crtc->id, crtc->props.active, 1);
+	set_plane_props(&atom, crtc->primary, crtc->id, fb_id, true);
+	return atomic_commit(drm->fd, &atom, output, mode ? DRM_MODE_ATOMIC_ALLOW_MODESET : 0);
+}
+
+static void atomic_conn_enable(struct wlr_backend_state *drm, struct wlr_output_state *output,
+		bool enable) {
+	struct wlr_drm_crtc *crtc = output->crtc;
+	struct atomic atom;
+
+	atomic_begin(crtc, &atom);
+	atomic_add(&atom, crtc->id, crtc->props.active, enable);
+	atomic_end(drm->fd, &atom);
+}
+
+bool legacy_crtc_set_cursor(struct wlr_backend_state *drm, struct wlr_drm_crtc *crtc,
+	struct gbm_bo *bo);
+
+static bool atomic_crtc_set_cursor(struct wlr_backend_state *drm, struct wlr_drm_crtc *crtc,
+		struct gbm_bo *bo) {
+	if (!crtc || !crtc->cursor) {
+		return true;
+	}
+
+	struct wlr_drm_plane *plane = crtc->cursor;
+	// We can't use atomic operations on fake planes
+	if (plane->id == 0) {
+		return legacy_crtc_set_cursor(drm, crtc, bo);
+	}
+
+	struct atomic atom;
+
+	atomic_begin(crtc, &atom);
+
+	if (bo) {
+		set_plane_props(&atom, plane, crtc->id, get_fb_for_bo(bo), false);
+	} else {
+		atomic_add(&atom, plane->id, plane->props.fb_id, 0);
+		atomic_add(&atom, plane->id, plane->props.crtc_id, 0);
+	}
+
+	return atomic_end(drm->fd, &atom);
+}
+
+bool legacy_crtc_move_cursor(struct wlr_backend_state *drm, struct wlr_drm_crtc *crtc,
+	int x, int y);
+
+static bool atomic_crtc_move_cursor(struct wlr_backend_state *drm, struct wlr_drm_crtc *crtc,
+		int x, int y) {
+	struct wlr_drm_plane *plane = crtc->cursor;
+	// We can't use atomic operations on fake planes
+	if (plane->id == 0) {
+		return legacy_crtc_move_cursor(drm, crtc, x, y);
+	}
+
+	struct atomic atom;
+
+	atomic_begin(crtc, &atom);
+	atomic_add(&atom, plane->id, plane->props.crtc_x, x);
+	atomic_add(&atom, plane->id, plane->props.crtc_y, y);
+	return atomic_end(drm->fd, &atom);
+}
+
+const struct wlr_drm_interface atomic_iface = {
+	.conn_enable = atomic_conn_enable,
+	.crtc_pageflip = atomic_crtc_pageflip,
+	.crtc_set_cursor = atomic_crtc_set_cursor,
+	.crtc_move_cursor = atomic_crtc_move_cursor,
+};

--- a/backend/drm/drm-legacy.c
+++ b/backend/drm/drm-legacy.c
@@ -1,0 +1,58 @@
+#include <gbm.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#include <wlr/util/log.h>
+#include "backend/drm.h"
+#include "backend/drm-util.h"
+
+static bool legacy_crtc_pageflip(struct wlr_backend_state *drm, struct wlr_output_state *output,
+		struct wlr_drm_crtc *crtc, uint32_t fb_id, drmModeModeInfo *mode) {
+	if (mode) {
+		drmModeSetCrtc(drm->fd, crtc->id, fb_id, 0, 0,
+			&output->connector, 1, mode);
+	}
+
+	drmModePageFlip(drm->fd, crtc->id, fb_id, DRM_MODE_PAGE_FLIP_EVENT, output);
+
+	return true;
+}
+
+static void legacy_conn_enable(struct wlr_backend_state *drm, struct wlr_output_state *output,
+		bool enable) {
+	drmModeConnectorSetProperty(drm->fd, output->connector, output->props.dpms,
+		enable ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF);
+}
+
+bool legacy_crtc_set_cursor(struct wlr_backend_state *drm, struct wlr_drm_crtc *crtc,
+		struct gbm_bo *bo) {
+	if (!crtc || !crtc->cursor) {
+		return true;
+	}
+
+	if (!bo) {
+		drmModeSetCursor(drm->fd, crtc->id, 0, 0, 0);
+		return true;
+	}
+
+	struct wlr_drm_plane *plane = crtc->cursor;
+
+	if (drmModeSetCursor(drm->fd, crtc->id, gbm_bo_get_handle(bo).u32,
+			plane->width, plane->height)) {
+		wlr_log_errno(L_ERROR, "Failed to set hardware cursor");
+		return false;
+	}
+
+	return true;
+}
+
+bool legacy_crtc_move_cursor(struct wlr_backend_state *drm, struct wlr_drm_crtc *crtc,
+		int x, int y) {
+	return !drmModeMoveCursor(drm->fd, crtc->id, x, y);
+}
+
+const struct wlr_drm_interface legacy_iface = {
+	.conn_enable = legacy_conn_enable,
+	.crtc_pageflip = legacy_crtc_pageflip,
+	.crtc_set_cursor = legacy_crtc_set_cursor,
+	.crtc_move_cursor = legacy_crtc_move_cursor,
+};

--- a/backend/drm/drm-properties.c
+++ b/backend/drm/drm-properties.c
@@ -27,6 +27,8 @@ static const struct prop_info connector_info[] = {
 
 static const struct prop_info crtc_info[] = {
 #define INDEX(name) (offsetof(union wlr_drm_crtc_props, name) / sizeof(uint32_t))
+	{ "ACTIVE",       INDEX(active) },
+	{ "MODE_ID",      INDEX(mode_id) },
 	{ "rotation",     INDEX(rotation) },
 	{ "scaling mode", INDEX(scaling_mode) },
 #undef INDEX

--- a/backend/egl.c
+++ b/backend/egl.c
@@ -162,6 +162,7 @@ error:
 }
 
 void wlr_egl_free(struct wlr_egl *egl) {
+	eglMakeCurrent(egl->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 	eglDestroyContext(egl->display, egl->context);
 	eglTerminate(egl->display);
 	eglReleaseThread();

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -7,6 +7,8 @@ wlr_files += files(
     'session/session.c',
     'drm/backend.c',
     'drm/drm.c',
+    'drm/drm-atomic.c',
+    'drm/drm-legacy.c',
     'drm/drm-properties.c',
     'drm/drm-util.c',
     'libinput/backend.c',

--- a/include/backend/drm-properties.h
+++ b/include/backend/drm-properties.h
@@ -27,8 +27,13 @@ union wlr_drm_crtc_props {
 		// Neither of these are guranteed to exist
 		uint32_t rotation;
 		uint32_t scaling_mode;
+
+		// atomic-modesetting only
+
+		uint32_t active;
+		uint32_t mode_id;
 	};
-	uint32_t props[2];
+	uint32_t props[4];
 };
 
 union wlr_drm_plane_props {

--- a/include/backend/drm-util.h
+++ b/include/backend/drm-util.h
@@ -12,6 +12,8 @@ int32_t calculate_refresh_rate(drmModeModeInfo *mode);
 void parse_edid(struct wlr_output *restrict output, size_t len, const uint8_t *data);
 // Returns the string representation of a DRM output type
 const char *conn_get_name(uint32_t type_id);
+// Returns the DRM framebuffer id for a gbm_bo
+uint32_t get_fb_for_bo(struct gbm_bo *bo);
 
 // Part of match_obj
 enum {


### PR DESCRIPTION
This adds support for the new atomic modesetting DRM interface, where available.
It's supposed to be quicker and prevent screen tearing, especially when working with planes.

Most DRM drivers don't have support for this yet, but the latest Linux version enables it by default for the i915 (intel) driver, which is what I tested it on. amdgpu is supposed to get it when their DC/DAL code lands. I have no idea when radeon or nouveau is going to get it.

This splits the DRM functionality between 'drm-legacy' and 'drm-atomic' and creates an interface for the common DRM code to use.