### PR TITLE
Implement wlr_region using pixman

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -7,6 +7,7 @@ packages:
   - libinput
   - libxkbcommon
   - libcap
+  - pixman
   - clang
 sources:
   - https://git.sr.ht/~sircmpwn/wlroots

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ arch:
     - wayland-protocols
     - mesa
     - libinput
+    - pixman
     - libxkbcommon
     - libcap
   script:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ WIP - [Status](https://github.com/SirCmpwn/wlroots/issues/9)
 
 Install dependencies:
 
-* cmake
 * wayland
 * wayland-protocols
 * EGL
@@ -17,6 +16,7 @@ Install dependencies:
 * GBM
 * libinput
 * udev
+* pixman
 * systemd (optional, for logind support)
 * libcap (optional, for capability support)
 * asciidoc (optional, for man pages)

--- a/include/wlr/types/wlr_region.h
+++ b/include/wlr/types/wlr_region.h
@@ -1,0 +1,10 @@
+#ifndef _WLR_TYPES_REGION_H
+#define _WLR_TYPES_REGION_H
+
+struct wl_resource;
+
+// Implements the given resource as region.
+// Sets the associated pixman_region32_t as userdata.
+void wlr_region_create(struct wl_resource *res);
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ dep_gbm            = dependency('gbm')
 dep_libinput       = dependency('libinput')
 dep_xkbcommon      = dependency('xkbcommon')
 dep_udev           = dependency('libudev')
+dep_pixman           = dependency('pixman-1')
 dep_libcap         = dependency('libcap', required: false)
 dep_systemd        = dependency('libsystemd', required: false)
 dep_math           = cc.find_library('m', required: false)
@@ -46,6 +47,7 @@ all_deps = [
     dep_libinput,
     dep_xkbcommon,
     dep_udev,
+    dep_pixman,
     dep_libcap,
     dep_systemd,
     dep_math,

--- a/types/meson.build
+++ b/types/meson.build
@@ -3,6 +3,7 @@ wlr_files += files(
     'wlr_keyboard.c',
     'wlr_output.c',
     'wlr_pointer.c',
+    'wlr_region.c',
     'wlr_tablet_pad.c',
     'wlr_tablet_tool.c',
     'wlr_touch.c',

--- a/types/wlr_region.c
+++ b/types/wlr_region.c
@@ -1,0 +1,44 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <wayland-server.h>
+#include <pixman.h>
+
+static void region_add(struct wl_client *client, struct wl_resource *resource,
+		int32_t x, int32_t y, int32_t width, int32_t height) {
+	pixman_region32_t *region = wl_resource_get_user_data(resource);
+	pixman_region32_union_rect(region, region, x, y, width, height);
+}
+
+static void region_subtract(struct wl_client *client, struct wl_resource *resource,
+		int32_t x, int32_t y, int32_t width, int32_t height) {
+	pixman_region32_t *region = wl_resource_get_user_data(resource);
+	pixman_region32_union_rect(region, region, x, y, width, height);
+
+	pixman_region32_t rect;
+	pixman_region32_init_rect(&rect, x, y, width, height);
+	pixman_region32_subtract(region, region, &rect);
+	pixman_region32_fini(&rect);
+}
+
+static void region_destroy(struct wl_client *client, struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+
+static const struct wl_region_interface region_interface = {
+	region_destroy,
+	region_add,
+	region_subtract,
+};
+
+static void destroy_region(struct wl_resource *resource) {
+	pixman_region32_t *reg = wl_resource_get_user_data(resource);
+	pixman_region32_fini(reg);
+	free(reg);
+}
+
+void wlr_region_create(struct wl_resource *res) {
+	pixman_region32_t *region = calloc(1, sizeof(pixman_region32_t));
+	pixman_region32_init(region);
+	wl_resource_set_implementation(res, &region_interface, region, destroy_region);
+}


### PR DESCRIPTION
Rather small pr, makes wlr dependent on pixman.
Will be needed to further implement wl_surface.
Not sure if it is ok to not use something wlr_region and instead directly setting the pixman region as the regions resource user data.