### PR TITLE
Implement drm (egl) buffer attaching

### DIFF
--- a/backend/backend.c
+++ b/backend/backend.c
@@ -39,6 +39,13 @@ void wlr_backend_destroy(struct wlr_backend *backend) {
 	free(backend);
 }
 
+struct wlr_egl *wlr_backend_get_egl(struct wlr_backend *backend) {
+	if (!backend->impl->get_egl) {
+		return NULL;
+	}
+	return backend->impl->get_egl(backend->state);
+}
+
 static struct wlr_backend *attempt_wl_backend(struct wl_display *display) {
 	struct wlr_backend *backend = wlr_wl_backend_create(display);
 	if (backend) {

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -149,6 +149,10 @@ struct wlr_backend *wlr_drm_backend_create(struct wl_display *display,
 		goto error_event;
 	}
 
+	if (!wlr_egl_bind_display(&drm->renderer.egl, display)) {
+		wlr_log(L_INFO, "Failed to bind egl/wl display: %s", egl_error());
+	}
+
 	return backend;
 
 error_event:

--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -12,6 +12,7 @@
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/util/list.h>
 #include <wlr/util/log.h>
+#include <wlr/egl.h>
 #include "backend/udev.h"
 #include "backend/drm.h"
 
@@ -38,9 +39,14 @@ static void wlr_drm_backend_destroy(struct wlr_backend_state *drm) {
 	free(drm);
 }
 
+static struct wlr_egl *wlr_drm_backend_get_egl(struct wlr_backend_state *drm) {
+	return &drm->renderer.egl;
+}
+
 static struct wlr_backend_impl backend_impl = {
 	.init = wlr_drm_backend_init,
-	.destroy = wlr_drm_backend_destroy
+	.destroy = wlr_drm_backend_destroy,
+	.get_egl = wlr_drm_backend_get_egl
 };
 
 static void session_signal(struct wl_listener *listener, void *data) {

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -579,7 +579,7 @@ static bool wlr_drm_output_set_cursor(struct wlr_output_state *output,
 		wlr_matrix_texture(plane->matrix, plane->width, plane->height,
 			output->base->transform ^ WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
-		plane->wlr_rend = wlr_gles2_renderer_init();
+		plane->wlr_rend = wlr_gles2_renderer_init(&output->renderer->egl);
 		if (!plane->wlr_rend) {
 			return false;
 		}

--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -579,7 +579,7 @@ static bool wlr_drm_output_set_cursor(struct wlr_output_state *output,
 		wlr_matrix_texture(plane->matrix, plane->width, plane->height,
 			output->base->transform ^ WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
-		plane->wlr_rend = wlr_gles2_renderer_init(&output->renderer->egl);
+		plane->wlr_rend = wlr_gles2_renderer_init(drm->base);
 		if (!plane->wlr_rend) {
 			return false;
 		}

--- a/backend/egl.c
+++ b/backend/egl.c
@@ -231,8 +231,7 @@ bool wlr_egl_query_buffer(struct wl_resource *buf, int attrib, int *value) {
 }
 
 EGLImage wlr_egl_create_image(EGLenum target,
-		EGLClientBuffer buffer, const EGLint *attribs)
-{
+		EGLClientBuffer buffer, const EGLint *attribs) {
 	if (!egl_global || !eglCreateImageKHR) {
 		return false;
 	}
@@ -241,8 +240,7 @@ EGLImage wlr_egl_create_image(EGLenum target,
 		buffer, attribs);
 }
 
-bool wlr_egl_destroy_image(EGLImage image)
-{
+bool wlr_egl_destroy_image(EGLImage image) {
 	if (!egl_global || !eglDestroyImageKHR) {
 		return false;
 	}

--- a/backend/meson.build
+++ b/backend/meson.build
@@ -1,6 +1,5 @@
 wlr_files += files(
     'backend.c',
-    'egl.c',
     'udev.c',
     'session/direct-ipc.c',
     'session/direct.c',

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -38,9 +38,21 @@ static void multi_backend_destroy(struct wlr_backend_state *state) {
 	free(state);
 }
 
+static struct wlr_egl *multi_backend_get_egl(struct wlr_backend_state *state) {
+	for (size_t i = 0; i < state->backends->length; ++i) {
+		struct subbackend_state *sub = state->backends->items[i];
+		struct wlr_egl *egl = wlr_backend_get_egl(sub->backend);
+		if (egl) {
+			return egl;
+		}
+	}
+	return NULL;
+}
+
 struct wlr_backend_impl backend_impl = {
 	.init = multi_backend_init,
-	.destroy = multi_backend_destroy
+	.destroy = multi_backend_destroy,
+	.get_egl = multi_backend_get_egl
 };
 
 struct wlr_backend *wlr_multi_backend_create(struct wlr_session *session,

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -4,6 +4,7 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <wayland-server.h>
+#include <wlr/egl.h>
 #include <wlr/backend/interface.h>
 #include <wlr/interfaces/wlr_output.h>
 #include <wlr/interfaces/wlr_input_device.h>
@@ -95,9 +96,14 @@ static void wlr_wl_backend_destroy(struct wlr_backend_state *state) {
 	free(state);
 }
 
+static struct wlr_egl *wlr_wl_backend_get_egl(struct wlr_backend_state *state) {
+	return &state->egl;
+}
+
 static struct wlr_backend_impl backend_impl = {
 	.init = wlr_wl_backend_init,
-	.destroy = wlr_wl_backend_destroy
+	.destroy = wlr_wl_backend_destroy,
+	.get_egl = wlr_wl_backend_get_egl
 };
 
 bool wlr_backend_is_wl(struct wlr_backend *b) {

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -52,6 +52,8 @@ static bool wlr_wl_backend_init(struct wlr_backend_state* state) {
 	}
 
 	wlr_egl_init(&state->egl, EGL_PLATFORM_WAYLAND_EXT, state->remote_display);
+	wlr_egl_bind_display(&state->egl, state->local_display);
+
 	for (size_t i = 0; i < state->requested_outputs; ++i) {
 		wlr_wl_output_create(state->backend);
 	}

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -117,6 +117,7 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 	strncpy(wlr_output->model, "wayland", sizeof(wlr_output->model));
 	snprintf(wlr_output->name, sizeof(wlr_output->name), "WL-%zd",
 			backend->outputs->length + 1);
+	wlr_output_update_matrix(wlr_output);
 
 	ostate->backend = backend;
 	ostate->wlr_output = wlr_output;

--- a/examples/compositor.h
+++ b/examples/compositor.h
@@ -14,6 +14,10 @@ struct wl_compositor_state {
 void wl_compositor_init(struct wl_display *display,
 		struct wl_compositor_state *state, struct wlr_renderer *renderer);
 
+struct wlr_surface;
+void wl_compositor_surface_destroyed(struct wl_compositor_state *compositor,
+		struct wlr_surface *surface);
+
 struct wl_shell_state {
 	struct wl_global *wl_global;
 	struct wl_list wl_resources;

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -68,7 +68,7 @@ int main() {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend);
 	wl_display_init_shm(compositor.display);
 	wl_compositor_init(compositor.display, &state.compositor, state.renderer);
 	wl_shell_init(compositor.display, &state.shell);

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -67,7 +67,7 @@ int main() {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
 	wl_display_init_shm(compositor.display);
 	wl_compositor_init(compositor.display, &state.compositor, state.renderer);
 	wl_shell_init(compositor.display, &state.shell);

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -67,7 +67,7 @@ int main() {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
+	state.renderer = wlr_gles2_renderer_init();
 	wl_display_init_shm(compositor.display);
 	wl_compositor_init(compositor.display, &state.compositor, state.renderer);
 	wl_shell_init(compositor.display, &state.shell);

--- a/examples/compositor/wl_compositor.c
+++ b/examples/compositor/wl_compositor.c
@@ -6,9 +6,8 @@
 #include "compositor.h"
 
 static void destroy_surface_listener(struct wl_listener *listener, void *data) {
-	struct wl_compositor_state *state;
-	struct wlr_surface *surface = data;
-	state = wl_container_of(listener, state, destroy_surface_listener);
+	struct wlr_surface *surface = wl_resource_get_user_data(data);
+	struct wl_compositor_state *state = surface->compositor_data;
 
 	struct wl_resource *res = NULL;
 	wl_list_for_each(res, &state->surfaces, link) {
@@ -25,8 +24,11 @@ static void wl_compositor_create_surface(struct wl_client *client,
 	struct wl_resource *surface_resource = wl_resource_create(client,
 			&wl_surface_interface, wl_resource_get_version(resource), id);
 	struct wlr_surface *surface = wlr_surface_create(surface_resource, state->renderer);
+	surface->compositor_data = state;
+	surface->compositor_listener.notify = &destroy_surface_listener;
+	wl_resource_add_destroy_listener(surface_resource, &surface->compositor_listener);
+
 	wl_list_insert(&state->surfaces, wl_resource_get_link(surface_resource));
-	wl_signal_add(&surface->signals.destroy, &state->destroy_surface_listener);
 }
 
 static void wl_compositor_create_region(struct wl_client *client,
@@ -73,7 +75,6 @@ void wl_compositor_init(struct wl_display *display,
 		&wl_compositor_interface, 4, state, wl_compositor_bind);
 	state->wl_global = wl_global;
 	state->renderer = renderer;
-	state->destroy_surface_listener.notify = destroy_surface_listener;
 	wl_list_init(&state->wl_resources);
 	wl_list_init(&state->surfaces);
 }

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
+	state.renderer = wlr_gles2_renderer_init();
 	state.cat_texture = wlr_render_texture_init(state.renderer);
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ABGR8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend);
 	state.cat_texture = wlr_render_texture_init(state.renderer);
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ABGR8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
 	state.cat_texture = wlr_render_texture_init(state.renderer);
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ABGR8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -152,8 +152,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
-
+	state.renderer = wlr_gles2_renderer_init();
 	compositor_run(&compositor);
 
 	wlr_renderer_destroy(state.renderer);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend);
 	compositor_run(&compositor);
 
 	wlr_renderer_destroy(state.renderer);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
 
 	compositor_run(&compositor);
 

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
 	state.cat_texture = wlr_render_texture_init(state.renderer);
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ARGB8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend->egl);
+	state.renderer = wlr_gles2_renderer_init();
 	state.cat_texture = wlr_render_texture_init(state.renderer);
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ARGB8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init();
+	state.renderer = wlr_gles2_renderer_init(compositor.backend);
 	state.cat_texture = wlr_render_texture_init(state.renderer);
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ARGB8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);

--- a/include/backend/drm.h
+++ b/include/backend/drm.h
@@ -12,9 +12,9 @@
 
 #include <wlr/backend/session.h>
 #include <wlr/backend/drm.h>
+#include <wlr/egl.h>
 #include <wlr/util/list.h>
 
-#include <backend/egl.h>
 #include <backend/udev.h>
 #include "drm-properties.h"
 

--- a/include/backend/egl.h
+++ b/include/backend/egl.h
@@ -2,17 +2,72 @@
 #define WLR_BACKEND_EGL_H
 
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include <stdbool.h>
 
 struct wlr_egl {
 	EGLDisplay display;
 	EGLConfig config;
 	EGLContext context;
+
+	const char *egl_exts;
+	const char *gl_exts;
+
+	struct wl_display *wl_display;
 };
 
-const char *egl_error(void);
+/**
+ *  Initializes an egl context for the given platform and remote display.
+ * Will attempt to load all possibly required api functions.
+ */
 bool wlr_egl_init(struct wlr_egl *egl, EGLenum platform, void *display);
+
+/**
+ * Frees all related egl resources, makes the context not-current and
+ * unbinds a bound wayland display.
+ */
 void wlr_egl_free(struct wlr_egl *egl);
+
+/**
+ * Binds the given display to the egl instance.
+ * This will allow clients to create egl surfaces from wayland ones and render to it.
+ */
+bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display);
+
+/**
+ * Queries information about the given (potential egl/drm) buffer, returns
+ * the information in value.
+ * Refer to eglQueryWaylandBufferWL for more information about attrib and value.
+ * Makes only sense when a wl_display was bound to it since otherwise there
+ * cannot be any egl/drm buffers.
+ * Will only work after a wlr_egl objct was initialized and if the needed egl extension
+ * is present.
+ */
+bool wlr_egl_query_buffer(struct wl_resource *buf,
+	EGLint attrib, EGLint *value);
+
+/**
+ * Returns a surface for the given native window
+ * The window must match the remote display the wlr_egl was created with.
+ */
 EGLSurface wlr_egl_create_surface(struct wlr_egl *egl, void *window);
+
+/**
+ * Creates an egl image from the given client buffer and attributes.
+ * Will only work after a wlr_egl objct was initialized and if the needed egl extension
+ * is present.
+ */
+EGLImageKHR wlr_egl_create_image(EGLenum target, EGLClientBuffer buffer,
+	const EGLint *attribs);
+
+/**
+ * Destroys an egl image created with the given wlr_egl.
+ */
+bool wlr_egl_destroy_image(EGLImageKHR image);
+
+/**
+ * Returns a string for the last error ocurred with egl.
+ */
+const char *egl_error(void);
 
 #endif

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -4,10 +4,10 @@
 #include <wayland-client.h>
 #include <wayland-server.h>
 #include <wayland-egl.h>
+#include <wlr/egl.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/util/list.h>
-#include "backend/egl.h"
 
 struct wlr_backend_state {
 	/* local state */

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -7,6 +7,8 @@
 #include <GLES2/gl2ext.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <wlr/egl.h>
+#include <wlr/backend.h>
 #include <wlr/render.h>
 #include <wlr/util/log.h>
 
@@ -19,8 +21,14 @@ struct pixel_format {
 	GLuint *shader;
 };
 
+struct wlr_renderer_state {
+	struct wlr_renderer *renderer;
+	struct wlr_egl *egl;
+};
+
 struct wlr_texture_state {
 	struct wlr_texture *wlr_texture;
+	struct wlr_egl *egl;
 	GLuint tex_id;
 	const struct pixel_format *pixel_format;
 	EGLImageKHR image;

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -4,8 +4,13 @@
 #include <string.h>
 #include <stdbool.h>
 #include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
 #include <wlr/render.h>
 #include <wlr/util/log.h>
+
+extern PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
 
 struct pixel_format {
 	uint32_t wl_format;
@@ -18,6 +23,7 @@ struct wlr_texture_state {
 	struct wlr_texture *wlr_texture;
 	GLuint tex_id;
 	const struct pixel_format *pixel_format;
+	EGLImageKHR image;
 };
 
 struct shaders {
@@ -25,6 +31,7 @@ struct shaders {
 	GLuint rgba, rgbx;
 	GLuint quad;
 	GLuint ellipse;
+	Gluint external;
 };
 
 extern struct shaders shaders;
@@ -39,6 +46,7 @@ extern const GLchar ellipse_fragment_src[];
 extern const GLchar vertex_src[];
 extern const GLchar fragment_src_rgba[];
 extern const GLchar fragment_src_rgbx[];
+extern const GLchar fragment_src_external[];
 
 bool _gles2_flush_errors(const char *file, int line);
 #define gles2_flush_errors(...) \

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -31,7 +31,7 @@ struct shaders {
 	GLuint rgba, rgbx;
 	GLuint quad;
 	GLuint ellipse;
-	Gluint external;
+	GLuint external;
 };
 
 extern struct shaders shaders;

--- a/include/wlr/backend.h
+++ b/include/wlr/backend.h
@@ -3,6 +3,7 @@
 
 #include <wayland-server.h>
 #include <wlr/backend/session.h>
+#include <wlr/egl.h>
 
 struct wlr_backend_impl;
 struct wlr_backend_state;
@@ -22,5 +23,6 @@ struct wlr_backend {
 struct wlr_backend *wlr_backend_autocreate(struct wl_display *display);
 bool wlr_backend_init(struct wlr_backend *backend);
 void wlr_backend_destroy(struct wlr_backend *backend);
+struct wlr_egl *wlr_backend_get_egl(struct wlr_backend *backend);
 
 #endif

--- a/include/wlr/backend/interface.h
+++ b/include/wlr/backend/interface.h
@@ -3,12 +3,14 @@
 
 #include <stdbool.h>
 #include <wlr/backend.h>
+#include <wlr/egl.h>
 
 struct wlr_backend_state;
 
 struct wlr_backend_impl {
 	bool (*init)(struct wlr_backend_state *state);
 	void (*destroy)(struct wlr_backend_state *state);
+	struct wlr_egl *(*get_egl)(struct wlr_backend_state *state);
 };
 
 struct wlr_backend *wlr_backend_create(const struct wlr_backend_impl *impl,

--- a/include/wlr/egl.h
+++ b/include/wlr/egl.h
@@ -1,5 +1,5 @@
-#ifndef WLR_BACKEND_EGL_H
-#define WLR_BACKEND_EGL_H
+#ifndef WLR_EGL_H
+#define WLR_EGL_H
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -10,12 +10,22 @@ struct wlr_egl {
 	EGLConfig config;
 	EGLContext context;
 
+	PFNEGLGETPLATFORMDISPLAYEXTPROC get_platform_display;
+	PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC create_platform_window_surface;
+
+	PFNEGLCREATEIMAGEKHRPROC eglCreateImageKHR;
+	PFNEGLDESTROYIMAGEKHRPROC eglDestroyImageKHR;
+	PFNEGLQUERYWAYLANDBUFFERWL eglQueryWaylandBufferWL;
+	PFNEGLBINDWAYLANDDISPLAYWL eglBindWaylandDisplayWL;
+	PFNEGLUNBINDWAYLANDDISPLAYWL eglUnbindWaylandDisplayWL;
+
 	const char *egl_exts;
 	const char *gl_exts;
 
 	struct wl_display *wl_display;
 };
 
+// TODO: Allocate and return a wlr_egl
 /**
  *  Initializes an egl context for the given platform and remote display.
  * Will attempt to load all possibly required api functions.
@@ -35,15 +45,9 @@ void wlr_egl_free(struct wlr_egl *egl);
 bool wlr_egl_bind_display(struct wlr_egl *egl, struct wl_display *local_display);
 
 /**
- * Queries information about the given (potential egl/drm) buffer, returns
- * the information in value.
- * Refer to eglQueryWaylandBufferWL for more information about attrib and value.
- * Makes only sense when a wl_display was bound to it since otherwise there
- * cannot be any egl/drm buffers.
- * Will only work after a wlr_egl objct was initialized and if the needed egl extension
- * is present.
+ * Refer to the eglQueryWaylandBufferWL extension function.
  */
-bool wlr_egl_query_buffer(struct wl_resource *buf,
+bool wlr_egl_query_buffer(struct wlr_egl *egl, struct wl_resource *buf,
 	EGLint attrib, EGLint *value);
 
 /**
@@ -54,16 +58,14 @@ EGLSurface wlr_egl_create_surface(struct wlr_egl *egl, void *window);
 
 /**
  * Creates an egl image from the given client buffer and attributes.
- * Will only work after a wlr_egl objct was initialized and if the needed egl extension
- * is present.
  */
-EGLImageKHR wlr_egl_create_image(EGLenum target, EGLClientBuffer buffer,
-	const EGLint *attribs);
+EGLImageKHR wlr_egl_create_image(struct wlr_egl *egl,
+		EGLenum target, EGLClientBuffer buffer, const EGLint *attribs);
 
 /**
  * Destroys an egl image created with the given wlr_egl.
  */
-bool wlr_egl_destroy_image(EGLImageKHR image);
+bool wlr_egl_destroy_image(struct wlr_egl *egl, EGLImageKHR image);
 
 /**
  * Returns a string for the last error ocurred with egl.

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -44,6 +44,11 @@ void wlr_render_colored_ellipse(struct wlr_renderer *r,
 const enum wl_shm_format *wlr_renderer_get_formats(
 		struct wlr_renderer *r, size_t *len);
 /**
+ * Returns true if this wl_buffer is a DRM buffer.
+ */
+bool wlr_renderer_buffer_is_drm(struct wlr_renderer *renderer,
+		struct wl_resource *buffer);
+/**
  * Destroys this wlr_renderer. Textures must be destroyed separately.
  */
 void wlr_renderer_destroy(struct wlr_renderer *renderer);

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -65,7 +65,7 @@ struct wlr_texture {
  * Copies pixels to this texture. The buffer is not accessed after this function
  * returns.
  */
-bool wlr_texture_upload_pixels(struct wlr_texture *surf,
+bool wlr_texture_upload_pixels(struct wlr_texture *tex,
 		enum wl_shm_format format, int stride, int width, int height,
 		const unsigned char *pixels);
 /**
@@ -80,8 +80,17 @@ bool wlr_texture_update_pixels(struct wlr_texture *surf,
  * Copies pixels from a wl_shm_buffer into this texture. The buffer is not
  * accessed after this function returns.
  */
-bool wlr_texture_upload_shm(struct wlr_texture *surf, uint32_t format,
+bool wlr_texture_upload_shm(struct wlr_texture *tex, uint32_t format,
 		struct wl_shm_buffer *shm);
+
+/**
+ * Attaches the contents from the given wl_drm wl_buffer resource onto the
+ * texture. The wl_resource is not used after this call.
+ * Will fail (return false) if the given resource is no drm buffer.
+ */
+ bool wlr_texture_upload_drm(struct wlr_texture *tex,
+ 	struct wl_resource *drm_buffer);
+
 /**
  * Copies a rectangle of pixels from a wl_shm_buffer onto the texture. The
  * buffer is not accessed after this function returns. Under some circumstances,

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -1,8 +1,9 @@
 #ifndef _WLR_GLES2_RENDERER_H
 #define _WLR_GLES2_RENDERER_H
 #include <wlr/render.h>
+#include <wlr/backend.h>
 
 struct wlr_egl;
-struct wlr_renderer *wlr_gles2_renderer_init();
+struct wlr_renderer *wlr_gles2_renderer_init(struct wlr_backend *backend);
 
 #endif

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -2,6 +2,7 @@
 #define _WLR_GLES2_RENDERER_H
 #include <wlr/render.h>
 
+struct wlr_egl;
 struct wlr_renderer *wlr_gles2_renderer_init();
 
 #endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -42,7 +42,8 @@ struct wlr_texture_impl {
 		struct wl_shm_buffer *shm);
 	bool (*update_shm)(struct wlr_texture_state *surf, uint32_t format,
 		int x, int y, int width, int height, struct wl_shm_buffer *shm);
-	// TODO: egl
+	bool (*upload_drm)(struct wlr_texture_state *state,
+		struct wl_resource *drm_buf);
 	void (*get_matrix)(struct wlr_texture_state *state,
 		float (*matrix)[16], const float (*projection)[16], int x, int y);
 	void (*bind)(struct wlr_texture_state *state);

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -25,6 +25,8 @@ struct wlr_renderer_impl {
 		const float (*color)[4], const float (*matrix)[16]);
 	const enum wl_shm_format *(*formats)(
 		struct wlr_renderer_state *state, size_t *len);
+	bool (*buffer_is_drm)(struct wlr_renderer_state *state,
+		struct wl_resource *buffer);
 	void (*destroy)(struct wlr_renderer_state *state);
 };
 

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -37,15 +37,17 @@ struct wlr_surface {
 	float surface_to_buffer_matrix[16];
 
 	struct {
-		struct wl_signal destroy;
 		struct wl_signal commit;
 	} signals;
 
 	struct wl_list frame_callback_list; // wl_surface.frame
+
+	struct wl_listener compositor_listener; // destroy listener used by compositor
+	void *compositor_data;
 };
 
 struct wlr_renderer;
 struct wlr_surface *wlr_surface_create(struct wl_resource *res,
-		struct wlr_renderer *renderer);
+	struct wlr_renderer *renderer);
 
 #endif

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -29,6 +29,7 @@ struct wlr_surface_state {
 
 struct wlr_surface {
 	struct wl_resource *resource;
+	struct wlr_renderer *renderer;
 	struct wlr_texture *texture;
 	struct wlr_surface_state current, pending;
 	const char *role; // the lifetime-bound role or null

--- a/render/gles2/shaders.c
+++ b/render/gles2/shaders.c
@@ -90,3 +90,13 @@ const GLchar fragment_src_rgbx[] =
 "   gl_FragColor.rgb = alpha * texture2D(tex, v_texcoord).rgb;"
 "   gl_FragColor.a = alpha;"
 "}";
+
+const GLchar fragment_src_external[] =
+"#extension GL_OES_EGL_image_external : require\n"
+"precision mediump float;"
+"uniform samplerExternalOES texture0;"
+"varying vec2 v_uv;"
+"void main() {"
+"  vec4 col = texture2D(texture0, v_uv);"
+"  gl_FragColor = vec4(col.rgb, col.a);"
+"}";

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -22,8 +22,9 @@ static struct pixel_format external_pixel_format = {
 };
 
 static void gles2_texture_gen_texture(struct wlr_texture_state *surface) {
-	if (surface->tex_id)
+	if (surface->tex_id) {
 		return;
+	}
 
 	GL_CALL(glGenTextures(1, &surface->tex_id));
 	GL_CALL(glBindTexture(GL_TEXTURE_2D, surface->tex_id));

--- a/render/meson.build
+++ b/render/meson.build
@@ -1,10 +1,11 @@
 wlr_files += files(
+    'egl.c',
     'matrix.c',
-    'wlr_renderer.c',
-    'wlr_texture.c',
     'gles2/pixel_format.c',
     'gles2/renderer.c',
     'gles2/shaders.c',
     'gles2/texture.c',
     'gles2/util.c',
+    'wlr_renderer.c',
+    'wlr_texture.c',
 )

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -46,3 +46,8 @@ const enum wl_shm_format *wlr_renderer_get_formats(
 		struct wlr_renderer *r, size_t *len) {
 	return r->impl->formats(r->state, len);
 }
+
+bool wlr_renderer_buffer_is_drm(struct wlr_renderer *r,
+		struct wl_resource *buffer) {
+	return r->impl->buffer_is_drm(r->state, buffer);
+}

--- a/render/wlr_texture.c
+++ b/render/wlr_texture.c
@@ -43,6 +43,11 @@ bool wlr_texture_update_shm(struct wlr_texture *texture, uint32_t format,
 			x, y, width, height, shm);
 }
 
+bool wlr_texture_upload_drm(struct wlr_texture *texture,
+		struct wl_resource *drm_buffer) {
+	return texture->impl->upload_drm(texture->state, drm_buffer);
+}
+
 void wlr_texture_get_matrix(struct wlr_texture *texture,
 		float (*matrix)[16], const float (*projection)[16], int x, int y) {
 	texture->impl->get_matrix(texture->state, matrix, projection, x, y);

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -133,6 +133,7 @@ bool wlr_output_set_cursor(struct wlr_output *output,
 		return true;
 	}
 
+	/*
 	wlr_log(L_INFO, "Falling back to software cursor");
 
 	output->cursor.is_sw = true;
@@ -149,8 +150,9 @@ bool wlr_output_set_cursor(struct wlr_output *output,
 
 	wlr_texture_upload_pixels(output->cursor.texture, WL_SHM_FORMAT_ARGB8888,
 		stride, width, height, buf);
+	*/
 
-	return true;
+	return false;
 }
 
 bool wlr_output_move_cursor(struct wlr_output *output, int x, int y) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -161,13 +161,13 @@ const struct wl_surface_interface surface_interface = {
 
 static void destroy_surface(struct wl_resource *resource) {
 	struct wlr_surface *surface = wl_resource_get_user_data(resource);
-	wl_signal_emit(&surface->signals.destroy, surface);
-	wlr_texture_destroy(surface->texture);
 
+	wlr_texture_destroy(surface->texture);
 	struct wlr_frame_callback *cb, *next;
 	wl_list_for_each_safe(cb, next, &surface->frame_callback_list, link) {
 		wl_resource_destroy(cb->resource);
 	}
+
 	free(surface);
 }
 
@@ -177,7 +177,6 @@ struct wlr_surface *wlr_surface_create(struct wl_resource *res,
 	surface->texture = wlr_render_texture_init(renderer);
 	surface->resource = res;
 	wl_signal_init(&surface->signals.commit);
-	wl_signal_init(&surface->signals.destroy);
 	wl_list_init(&surface->frame_callback_list);
 	wl_resource_set_implementation(res, &surface_interface,
 			surface, destroy_surface);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -99,12 +99,14 @@ static void surface_commit(struct wl_client *client,
 		// callbacks instead of immediately here
 		if (surface->current.buffer) {
 			struct wl_shm_buffer *buffer = wl_shm_buffer_get(surface->current.buffer);
-			if (!buffer) {
-				wlr_log(L_INFO, "Unknown buffer handle attached");
-			} else {
+			if (buffer) {
 				uint32_t format = wl_shm_buffer_get_format(buffer);
 				wlr_texture_upload_shm(surface->texture, format, buffer);
 				wl_resource_queue_event(surface->current.buffer, WL_BUFFER_RELEASE);
+			} else if (wlr_texture_upload_drm(surface->texture, surface->pending.buffer)) {
+				wl_resource_queue_event(surface->current.buffer, WL_BUFFER_RELEASE);
+			} else {
+				wlr_log(L_INFO, "Unknown buffer handle attached");
 			}
 		}
 	}


### PR DESCRIPTION
This adds support for attaching egl buffers (or more general and correct: buffers coming from wl_drm).
It expands wlr_egl to load the required extensions and makes the gles renderer dependent on the egl
object.

An unresolved problem that probably needs to be fixed until this can get merged is that i had to disable software cursor support in wlr_output.c since i don't think we currently have access to an wlr_egl object there. Is it ok by design that there are multiple renderer objects? Then i could add support for gles renderers that simply cannot attach drm buffers since they were initialized without a wlr_egl object.

Another quick workaround i used here that may be problematic is the fact that wlr_egl is now exposed from wlr_backend and this leads to an somewhat ugly situation in the multi backend. I don't think this can be handled in a better way with the current backend/egl design though.

Also it currently simply uses the rgba pixel format for the texture, not sure how this could be handled correctly (but it works, so...).