### PR TITLE
[WIP] Implement buffer damage and scaling

### DIFF
--- a/backend/meson.build
+++ b/backend/meson.build
@@ -30,4 +30,4 @@ endif
 
 lib_wlr_backend = static_library('wlr_backend', backend_files,
   include_directories: wlr_inc,
-  dependencies: [wayland_server, egl, gbm, libinput, systemd])
+  dependencies: [wayland_server, egl, gbm, libinput, systemd, pixman])

--- a/include/wlr/render/matrix.h
+++ b/include/wlr/render/matrix.h
@@ -2,6 +2,7 @@
 #define _WLR_RENDER_MATRIX_H
 
 #include <stdint.h>
+#include <pixman.h>
 
 void wlr_matrix_identity(float (*output)[16]);
 void wlr_matrix_translate(float (*output)[16], float x, float y, float z);
@@ -12,5 +13,8 @@ void wlr_matrix_mul(const float (*x)[16], const float (*y)[16], float (*product)
 enum wl_output_transform;
 void wlr_matrix_texture(float mat[static 16], int32_t width, int32_t height,
 		enum wl_output_transform transform);
+void wlr_matrix_transform_region(pixman_region32_t *dest,
+		float matrix[16],
+		pixman_region32_t *src);
 
 #endif

--- a/render/meson.build
+++ b/render/meson.build
@@ -10,4 +10,4 @@ lib_wlr_render = static_library('wlr_render', files(
         'wlr_texture.c',
     ),
     include_directories: wlr_inc,
-    dependencies: [glesv2, egl])
+    dependencies: [glesv2, egl, pixman])

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -5,6 +5,7 @@
 #include <wlr/egl.h>
 #include <wlr/render/interface.h>
 #include <wlr/types/wlr_surface.h>
+#include <wlr/render/matrix.h>
 
 static void surface_destroy(struct wl_client *client, struct wl_resource *resource) {
 	wl_resource_destroy(resource);
@@ -90,18 +91,51 @@ static void surface_set_input_region(struct wl_client *client,
 	}
 }
 
+static void wlr_surface_build_buffer_matrix(struct wlr_surface *surface) {
+	// TODO translate x/y/width/height
+	wlr_matrix_identity(&surface->buffer_to_surface_matrix);
+	// TODO properly invert a surface-to-buffer matrix like weston does
+	if (surface->current.scale != 0) {
+		float buffer_scale = 1.0f / (float)surface->current.scale;
+		wlr_matrix_scale(&surface->buffer_to_surface_matrix, buffer_scale,
+			buffer_scale, buffer_scale);
+	}
+}
+
 static void surface_commit(struct wl_client *client,
 		struct wl_resource *resource) {
 	struct wlr_surface *surface = wl_resource_get_user_data(resource);
+	surface->current.scale = surface->pending.scale;
+	wlr_surface_build_buffer_matrix(surface);
 
 	if ((surface->pending.invalid & WLR_SURFACE_INVALID_BUFFER)) {
 		surface->current.buffer = surface->pending.buffer;
 	}
 	if ((surface->pending.invalid & WLR_SURFACE_INVALID_SURFACE_DAMAGE)) {
-		// TODO: Sort out buffer damage too
 		pixman_region32_union(&surface->current.surface_damage,
 				&surface->current.surface_damage,
 				&surface->pending.surface_damage);
+
+		pixman_region32_union(&surface->current.buffer_damage,
+				&surface->current.buffer_damage,
+				&surface->pending.buffer_damage);
+
+		// wl_surface.damage_buffer needs to be clipped to the buffer,
+		// translated into surface co-ordinates and unioned with
+		// the other surface damage.
+		struct wl_shm_buffer *buffer = wl_shm_buffer_get(surface->current.buffer);
+		pixman_region32_t buffer_damage = surface->current.buffer_damage;
+		pixman_region32_intersect_rect(&buffer_damage, &buffer_damage, 0, 0,
+			wl_shm_buffer_get_width(buffer),
+			wl_shm_buffer_get_height(buffer));
+
+		pixman_region32_t transformed_buffer_damage;
+		wlr_matrix_transform_region(&transformed_buffer_damage,
+			surface->buffer_to_surface_matrix, &buffer_damage);
+
+		pixman_region32_union(&surface->current.surface_damage,
+			&surface->current.surface_damage, &transformed_buffer_damage);
+
 		// TODO: Surface sizing is complicated
 		//pixman_region32_intersect_rect(&surface->current.surface_damage,
 		//		&surface->current.surface_damage,
@@ -167,7 +201,8 @@ static void surface_set_buffer_transform(struct wl_client *client,
 static void surface_set_buffer_scale(struct wl_client *client,
 		struct wl_resource *resource,
 		int32_t scale) {
-	wlr_log(L_DEBUG, "TODO: surface set buffer scale");
+	struct wlr_surface *surface = wl_resource_get_user_data(resource);
+	surface->pending.scale = scale;
 }
 
 static void surface_damage_buffer(struct wl_client *client,
@@ -215,6 +250,8 @@ struct wlr_surface *wlr_surface_create(struct wl_resource *res,
 	surface->renderer = renderer;
 	surface->texture = wlr_render_texture_init(renderer);
 	surface->resource = res;
+	surface->current.scale = 1;
+	surface->pending.scale = 1;
 	wl_signal_init(&surface->signals.commit);
 	wl_list_init(&surface->frame_callback_list);
 	wl_resource_set_implementation(res, &surface_interface,

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -27,8 +27,8 @@ static void surface_damage(struct wl_client *client,
 	}
 	surface->pending.invalid |= WLR_SURFACE_INVALID_SURFACE_DAMAGE;
 	pixman_region32_union_rect(&surface->pending.surface_damage,
-				   &surface->pending.surface_damage,
-				   x, y, width, height);
+		&surface->pending.surface_damage,
+		x, y, width, height);
 }
 
 static void destroy_frame_callback(struct wl_resource *resource) {


### PR DESCRIPTION
It's sort of difficult to test this right now and the work I will do next might reveal some errors, but I think it is ok.

Try `./weston-simple-damage --scale=2` and compare it to `./weston-simple-damage --scale=2 --use-damage-buffer`. You'll notice that they both do not work now and I think that is the correct behavior. What I tested is that the damage rects are in the same coordinate system after they are applied (e.g., the damage box height/width is ~21 for every value you give to scale). I believe this is what is meant by converting buffer coordinates to surface coordinates.

Buffer scaling should not affect the size of the window presented on the screen. Try different scales in weston and you will see what I mean. Once that is fixed, we should see the little green ball move around with scale. That will be what I work on next.