### PR TITLE
Leak plumbing

### DIFF
--- a/backend/drm/backend.c
+++ b/backend/drm/backend.c
@@ -36,6 +36,7 @@ static void wlr_drm_backend_destroy(struct wlr_backend_state *drm) {
 	wlr_drm_resources_free(drm);
 	wlr_session_close_file(drm->session, drm->fd);
 	wl_event_source_remove(drm->drm_event);
+	list_free(drm->outputs);
 	free(drm);
 }
 

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -78,7 +78,19 @@ static bool wlr_libinput_backend_init(struct wlr_backend_state *state) {
 }
 
 static void wlr_libinput_backend_destroy(struct wlr_backend_state *state) {
-	// TODO
+	if (!state) {
+		return;
+	}
+
+	for (size_t i = 0; i < state->devices->length; i++) {
+		struct wlr_input_device *wlr_device = state->devices->items[i];
+
+		wlr_input_device_destroy(wlr_device);
+	}
+	list_free(state->devices);
+	libinput_unref(state->libinput);
+
+	free(state);
 }
 
 static struct wlr_backend_impl backend_impl = {

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -24,6 +24,11 @@ struct wlr_input_device *get_appropriate_device(
 }
 
 static void wlr_libinput_device_destroy(struct wlr_input_device_state *state) {
+	list_t *devices = libinput_device_get_user_data(state->handle);
+	// devices themselves are freed in wlr_libinput_backend_destroy
+	// this list only has a part of the same elements so just free list
+	list_free(devices);
+
 	libinput_device_unref(state->handle);
 	free(state);
 }

--- a/backend/libinput/keyboard.c
+++ b/backend/libinput/keyboard.c
@@ -45,20 +45,19 @@ void handle_keyboard_key(struct libinput_event *event,
 	}
 	struct libinput_event_keyboard *kbevent =
 		libinput_event_get_keyboard_event(event);
-	struct wlr_event_keyboard_key *wlr_event =
-		calloc(1, sizeof(struct wlr_event_keyboard_key));
-	wlr_event->time_sec = libinput_event_keyboard_get_time(kbevent);
-	wlr_event->time_usec = libinput_event_keyboard_get_time_usec(kbevent);
-	wlr_event->keycode = libinput_event_keyboard_get_key(kbevent);
+	struct wlr_event_keyboard_key wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_keyboard_get_time(kbevent);
+	wlr_event.time_usec = libinput_event_keyboard_get_time_usec(kbevent);
+	wlr_event.keycode = libinput_event_keyboard_get_key(kbevent);
 	enum libinput_key_state state = 
 		libinput_event_keyboard_get_key_state(kbevent);
 	switch (state) {
 	case LIBINPUT_KEY_STATE_RELEASED:
-		wlr_event->state = WLR_KEY_RELEASED;
+		wlr_event.state = WLR_KEY_RELEASED;
 		break;
 	case LIBINPUT_KEY_STATE_PRESSED:
-		wlr_event->state = WLR_KEY_PRESSED;
+		wlr_event.state = WLR_KEY_PRESSED;
 		break;
 	}
-	wl_signal_emit(&dev->keyboard->events.key, wlr_event);
+	wl_signal_emit(&dev->keyboard->events.key, &wlr_event);
 }

--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -23,13 +23,12 @@ void handle_pointer_motion(struct libinput_event *event,
 	}
 	struct libinput_event_pointer *pevent =
 		libinput_event_get_pointer_event(event);
-	struct wlr_event_pointer_motion *wlr_event =
-		calloc(1, sizeof(struct wlr_event_pointer_motion));
-	wlr_event->time_sec = libinput_event_pointer_get_time(pevent);
-	wlr_event->time_usec = libinput_event_pointer_get_time_usec(pevent);
-	wlr_event->delta_x = libinput_event_pointer_get_dx(pevent);
-	wlr_event->delta_y = libinput_event_pointer_get_dy(pevent);
-	wl_signal_emit(&dev->pointer->events.motion, wlr_event);
+	struct wlr_event_pointer_motion wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
+	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
+	wlr_event.delta_x = libinput_event_pointer_get_dx(pevent);
+	wlr_event.delta_y = libinput_event_pointer_get_dy(pevent);
+	wl_signal_emit(&dev->pointer->events.motion, &wlr_event);
 }
 
 void handle_pointer_motion_abs(struct libinput_event *event,
@@ -42,14 +41,13 @@ void handle_pointer_motion_abs(struct libinput_event *event,
 	}
 	struct libinput_event_pointer *pevent =
 		libinput_event_get_pointer_event(event);
-	struct wlr_event_pointer_motion_absolute *wlr_event =
-		calloc(1, sizeof(struct wlr_event_pointer_motion_absolute));
-	wlr_event->time_sec = libinput_event_pointer_get_time(pevent);
-	wlr_event->time_usec = libinput_event_pointer_get_time_usec(pevent);
-	wlr_event->x_mm = libinput_event_pointer_get_absolute_x(pevent);
-	wlr_event->y_mm = libinput_event_pointer_get_absolute_y(pevent);
-	libinput_device_get_size(device, &wlr_event->width_mm, &wlr_event->height_mm);
-	wl_signal_emit(&dev->pointer->events.motion_absolute, wlr_event);
+	struct wlr_event_pointer_motion_absolute wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
+	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
+	wlr_event.x_mm = libinput_event_pointer_get_absolute_x(pevent);
+	wlr_event.y_mm = libinput_event_pointer_get_absolute_y(pevent);
+	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
+	wl_signal_emit(&dev->pointer->events.motion_absolute, &wlr_event);
 }
 
 void handle_pointer_button(struct libinput_event *event,
@@ -62,20 +60,19 @@ void handle_pointer_button(struct libinput_event *event,
 	}
 	struct libinput_event_pointer *pevent =
 		libinput_event_get_pointer_event(event);
-	struct wlr_event_pointer_button *wlr_event =
-		calloc(1, sizeof(struct wlr_event_pointer_button));
-	wlr_event->time_sec = libinput_event_pointer_get_time(pevent);
-	wlr_event->time_usec = libinput_event_pointer_get_time_usec(pevent);
-	wlr_event->button = libinput_event_pointer_get_button(pevent);
+	struct wlr_event_pointer_button wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
+	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
+	wlr_event.button = libinput_event_pointer_get_button(pevent);
 	switch (libinput_event_pointer_get_button_state(pevent)) {
 	case LIBINPUT_BUTTON_STATE_PRESSED:
-		wlr_event->state = WLR_BUTTON_PRESSED;
+		wlr_event.state = WLR_BUTTON_PRESSED;
 		break;
 	case LIBINPUT_BUTTON_STATE_RELEASED:
-		wlr_event->state = WLR_BUTTON_RELEASED;
+		wlr_event.state = WLR_BUTTON_RELEASED;
 		break;
 	}
-	wl_signal_emit(&dev->pointer->events.button, wlr_event);
+	wl_signal_emit(&dev->pointer->events.button, &wlr_event);
 }
 
 void handle_pointer_axis(struct libinput_event *event,
@@ -88,22 +85,21 @@ void handle_pointer_axis(struct libinput_event *event,
 	}
 	struct libinput_event_pointer *pevent =
 		libinput_event_get_pointer_event(event);
-	struct wlr_event_pointer_axis *wlr_event =
-		calloc(1, sizeof(struct wlr_event_pointer_axis));
-	wlr_event->time_sec = libinput_event_pointer_get_time(pevent);
-	wlr_event->time_usec = libinput_event_pointer_get_time_usec(pevent);
+	struct wlr_event_pointer_axis wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_pointer_get_time(pevent);
+	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
 	switch (libinput_event_pointer_get_axis_source(pevent)) {
 	case LIBINPUT_POINTER_AXIS_SOURCE_WHEEL:
-		wlr_event->source = WLR_AXIS_SOURCE_WHEEL;
+		wlr_event.source = WLR_AXIS_SOURCE_WHEEL;
 		break;
 	case LIBINPUT_POINTER_AXIS_SOURCE_FINGER:
-		wlr_event->source = WLR_AXIS_SOURCE_FINGER;
+		wlr_event.source = WLR_AXIS_SOURCE_FINGER;
 		break;
 	case LIBINPUT_POINTER_AXIS_SOURCE_CONTINUOUS:
-		wlr_event->source = WLR_AXIS_SOURCE_CONTINUOUS;
+		wlr_event.source = WLR_AXIS_SOURCE_CONTINUOUS;
 		break;
 	case LIBINPUT_POINTER_AXIS_SOURCE_WHEEL_TILT:
-		wlr_event->source = WLR_AXIS_SOURCE_WHEEL_TILT;
+		wlr_event.source = WLR_AXIS_SOURCE_WHEEL_TILT;
 		break;
 	}
 	enum libinput_pointer_axis axies[] = {
@@ -114,15 +110,15 @@ void handle_pointer_axis(struct libinput_event *event,
 		if (libinput_event_pointer_has_axis(pevent, axies[i])) {
 			switch (axies[i]) {
 			case LIBINPUT_POINTER_AXIS_SCROLL_VERTICAL:
-				wlr_event->orientation = WLR_AXIS_ORIENTATION_VERTICAL;
+				wlr_event.orientation = WLR_AXIS_ORIENTATION_VERTICAL;
 				break;
 			case LIBINPUT_POINTER_AXIS_SCROLL_HORIZONTAL:
-				wlr_event->orientation = WLR_AXIS_ORIENTATION_HORIZONTAL;
+				wlr_event.orientation = WLR_AXIS_ORIENTATION_HORIZONTAL;
 				break;
 			}
-			wlr_event->delta = libinput_event_pointer_get_axis_value(
+			wlr_event.delta = libinput_event_pointer_get_axis_value(
 					pevent, axies[i]);
 		}
-		wl_signal_emit(&dev->pointer->events.axis, wlr_event);
+		wl_signal_emit(&dev->pointer->events.axis, &wlr_event);
 	}
 }

--- a/backend/libinput/tablet_pad.c
+++ b/backend/libinput/tablet_pad.c
@@ -23,20 +23,19 @@ void handle_tablet_pad_button(struct libinput_event *event,
 	}
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
-	struct wlr_event_tablet_pad_button *wlr_event =
-		calloc(1, sizeof(struct wlr_event_tablet_pad_button));
-	wlr_event->time_sec = libinput_event_tablet_pad_get_time(pevent);
-	wlr_event->time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
-	wlr_event->button = libinput_event_tablet_pad_get_button_number(pevent);
+	struct wlr_event_tablet_pad_button wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_tablet_pad_get_time(pevent);
+	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
+	wlr_event.button = libinput_event_tablet_pad_get_button_number(pevent);
 	switch (libinput_event_tablet_pad_get_button_state(pevent)) {
 	case LIBINPUT_BUTTON_STATE_PRESSED:
-		wlr_event->state = WLR_BUTTON_PRESSED;
+		wlr_event.state = WLR_BUTTON_PRESSED;
 		break;
 	case LIBINPUT_BUTTON_STATE_RELEASED:
-		wlr_event->state = WLR_BUTTON_RELEASED;
+		wlr_event.state = WLR_BUTTON_RELEASED;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_pad->events.button, wlr_event);
+	wl_signal_emit(&dev->tablet_pad->events.button, &wlr_event);
 }
 
 void handle_tablet_pad_ring(struct libinput_event *event,
@@ -49,21 +48,20 @@ void handle_tablet_pad_ring(struct libinput_event *event,
 	}
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
-	struct wlr_event_tablet_pad_ring *wlr_event =
-		calloc(1, sizeof(struct wlr_event_tablet_pad_ring));
-	wlr_event->time_sec = libinput_event_tablet_pad_get_time(pevent);
-	wlr_event->time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
-	wlr_event->ring = libinput_event_tablet_pad_get_ring_number(pevent);
-	wlr_event->position = libinput_event_tablet_pad_get_ring_position(pevent);
+	struct wlr_event_tablet_pad_ring wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_tablet_pad_get_time(pevent);
+	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
+	wlr_event.ring = libinput_event_tablet_pad_get_ring_number(pevent);
+	wlr_event.position = libinput_event_tablet_pad_get_ring_position(pevent);
 	switch (libinput_event_tablet_pad_get_ring_source(pevent)) {
 	case LIBINPUT_TABLET_PAD_RING_SOURCE_UNKNOWN:
-		wlr_event->source = WLR_TABLET_PAD_RING_SOURCE_UNKNOWN;
+		wlr_event.source = WLR_TABLET_PAD_RING_SOURCE_UNKNOWN;
 		break;
 	case LIBINPUT_TABLET_PAD_RING_SOURCE_FINGER:
-		wlr_event->source = WLR_TABLET_PAD_RING_SOURCE_FINGER;
+		wlr_event.source = WLR_TABLET_PAD_RING_SOURCE_FINGER;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_pad->events.ring, wlr_event);
+	wl_signal_emit(&dev->tablet_pad->events.ring, &wlr_event);
 }
 
 void handle_tablet_pad_strip(struct libinput_event *event,
@@ -76,19 +74,18 @@ void handle_tablet_pad_strip(struct libinput_event *event,
 	}
 	struct libinput_event_tablet_pad *pevent =
 		libinput_event_get_tablet_pad_event(event);
-	struct wlr_event_tablet_pad_strip *wlr_event =
-		calloc(1, sizeof(struct wlr_event_tablet_pad_strip));
-	wlr_event->time_sec = libinput_event_tablet_pad_get_time(pevent);
-	wlr_event->time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
-	wlr_event->strip = libinput_event_tablet_pad_get_strip_number(pevent);
-	wlr_event->position = libinput_event_tablet_pad_get_strip_position(pevent);
+	struct wlr_event_tablet_pad_strip wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_tablet_pad_get_time(pevent);
+	wlr_event.time_usec = libinput_event_tablet_pad_get_time_usec(pevent);
+	wlr_event.strip = libinput_event_tablet_pad_get_strip_number(pevent);
+	wlr_event.position = libinput_event_tablet_pad_get_strip_position(pevent);
 	switch (libinput_event_tablet_pad_get_strip_source(pevent)) {
 	case LIBINPUT_TABLET_PAD_STRIP_SOURCE_UNKNOWN:
-		wlr_event->source = WLR_TABLET_PAD_STRIP_SOURCE_UNKNOWN;
+		wlr_event.source = WLR_TABLET_PAD_STRIP_SOURCE_UNKNOWN;
 		break;
 	case LIBINPUT_TABLET_PAD_STRIP_SOURCE_FINGER:
-		wlr_event->source = WLR_TABLET_PAD_STRIP_SOURCE_FINGER;
+		wlr_event.source = WLR_TABLET_PAD_STRIP_SOURCE_FINGER;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_pad->events.strip, wlr_event);
+	wl_signal_emit(&dev->tablet_pad->events.strip, &wlr_event);
 }

--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -23,48 +23,47 @@ void handle_tablet_tool_axis(struct libinput_event *event,
 	}
 	struct libinput_event_tablet_tool *tevent =
 		libinput_event_get_tablet_tool_event(event);
-	struct wlr_event_tablet_tool_axis *wlr_event =
-		calloc(1, sizeof(struct wlr_event_tablet_tool_axis));
-	wlr_event->time_sec = libinput_event_tablet_tool_get_time(tevent);
-	wlr_event->time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
-	libinput_device_get_size(device, &wlr_event->width_mm, &wlr_event->height_mm);
+	struct wlr_event_tablet_tool_axis wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
+	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
 	if (libinput_event_tablet_tool_x_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_X;
-		wlr_event->x_mm = libinput_event_tablet_tool_get_x(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_X;
+		wlr_event.x_mm = libinput_event_tablet_tool_get_x(tevent);
 	}
 	if (libinput_event_tablet_tool_y_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_Y;
-		wlr_event->y_mm = libinput_event_tablet_tool_get_y(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_Y;
+		wlr_event.y_mm = libinput_event_tablet_tool_get_y(tevent);
 	}
 	if (libinput_event_tablet_tool_pressure_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_PRESSURE;
-		wlr_event->pressure = libinput_event_tablet_tool_get_pressure(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_PRESSURE;
+		wlr_event.pressure = libinput_event_tablet_tool_get_pressure(tevent);
 	}
 	if (libinput_event_tablet_tool_distance_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_DISTANCE;
-		wlr_event->distance = libinput_event_tablet_tool_get_distance(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_DISTANCE;
+		wlr_event.distance = libinput_event_tablet_tool_get_distance(tevent);
 	}
 	if (libinput_event_tablet_tool_tilt_x_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_TILT_X;
-		wlr_event->tilt_x = libinput_event_tablet_tool_get_tilt_x(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_TILT_X;
+		wlr_event.tilt_x = libinput_event_tablet_tool_get_tilt_x(tevent);
 	}
 	if (libinput_event_tablet_tool_tilt_y_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_TILT_Y;
-		wlr_event->tilt_y = libinput_event_tablet_tool_get_tilt_y(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_TILT_Y;
+		wlr_event.tilt_y = libinput_event_tablet_tool_get_tilt_y(tevent);
 	}
 	if (libinput_event_tablet_tool_rotation_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_ROTATION;
-		wlr_event->rotation = libinput_event_tablet_tool_get_rotation(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_ROTATION;
+		wlr_event.rotation = libinput_event_tablet_tool_get_rotation(tevent);
 	}
 	if (libinput_event_tablet_tool_slider_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_SLIDER;
-		wlr_event->slider = libinput_event_tablet_tool_get_slider_position(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_SLIDER;
+		wlr_event.slider = libinput_event_tablet_tool_get_slider_position(tevent);
 	}
 	if (libinput_event_tablet_tool_wheel_has_changed(tevent)) {
-		wlr_event->updated_axes |= WLR_TABLET_TOOL_AXIS_WHEEL;
-		wlr_event->wheel_delta = libinput_event_tablet_tool_get_wheel_delta(tevent);
+		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_WHEEL;
+		wlr_event.wheel_delta = libinput_event_tablet_tool_get_wheel_delta(tevent);
 	}
-	wl_signal_emit(&dev->tablet_tool->events.axis, wlr_event);
+	wl_signal_emit(&dev->tablet_tool->events.axis, &wlr_event);
 }
 
 void handle_tablet_tool_proximity(struct libinput_event *event,
@@ -77,20 +76,19 @@ void handle_tablet_tool_proximity(struct libinput_event *event,
 	}
 	struct libinput_event_tablet_tool *tevent =
 		libinput_event_get_tablet_tool_event(event);
-	struct wlr_event_tablet_tool_proximity *wlr_event =
-		calloc(1, sizeof(struct wlr_event_tablet_tool_proximity));
-	wlr_event->time_sec = libinput_event_tablet_tool_get_time(tevent);
-	wlr_event->time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	struct wlr_event_tablet_tool_proximity wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
+	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
 	switch (libinput_event_tablet_tool_get_proximity_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_OUT:
-		wlr_event->state = WLR_TABLET_TOOL_PROXIMITY_OUT;
+		wlr_event.state = WLR_TABLET_TOOL_PROXIMITY_OUT;
 		break;
 	case LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN:
-		wlr_event->state = WLR_TABLET_TOOL_PROXIMITY_IN;
+		wlr_event.state = WLR_TABLET_TOOL_PROXIMITY_IN;
 		handle_tablet_tool_axis(event, device);
 		break;
 	}
-	wl_signal_emit(&dev->tablet_tool->events.proximity, wlr_event);
+	wl_signal_emit(&dev->tablet_tool->events.proximity, &wlr_event);
 }
 
 void handle_tablet_tool_tip(struct libinput_event *event,
@@ -104,19 +102,18 @@ void handle_tablet_tool_tip(struct libinput_event *event,
 	handle_tablet_tool_axis(event, device);
 	struct libinput_event_tablet_tool *tevent =
 		libinput_event_get_tablet_tool_event(event);
-	struct wlr_event_tablet_tool_tip *wlr_event =
-		calloc(1, sizeof(struct wlr_event_tablet_tool_tip));
-	wlr_event->time_sec = libinput_event_tablet_tool_get_time(tevent);
-	wlr_event->time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	struct wlr_event_tablet_tool_tip wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
+	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
 	switch (libinput_event_tablet_tool_get_tip_state(tevent)) {
 	case LIBINPUT_TABLET_TOOL_TIP_UP:
-		wlr_event->state = WLR_TABLET_TOOL_TIP_UP;
+		wlr_event.state = WLR_TABLET_TOOL_TIP_UP;
 		break;
 	case LIBINPUT_TABLET_TOOL_TIP_DOWN:
-		wlr_event->state = WLR_TABLET_TOOL_TIP_DOWN;
+		wlr_event.state = WLR_TABLET_TOOL_TIP_DOWN;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_tool->events.tip, wlr_event);
+	wl_signal_emit(&dev->tablet_tool->events.tip, &wlr_event);
 }
 
 void handle_tablet_tool_button(struct libinput_event *event,
@@ -130,18 +127,17 @@ void handle_tablet_tool_button(struct libinput_event *event,
 	handle_tablet_tool_axis(event, device);
 	struct libinput_event_tablet_tool *tevent =
 		libinput_event_get_tablet_tool_event(event);
-	struct wlr_event_tablet_tool_button *wlr_event =
-		calloc(1, sizeof(struct wlr_event_tablet_tool_button));
-	wlr_event->time_sec = libinput_event_tablet_tool_get_time(tevent);
-	wlr_event->time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
-	wlr_event->button = libinput_event_tablet_tool_get_button(tevent);
+	struct wlr_event_tablet_tool_button wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
+	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
+	wlr_event.button = libinput_event_tablet_tool_get_button(tevent);
 	switch (libinput_event_tablet_tool_get_button_state(tevent)) {
 	case LIBINPUT_BUTTON_STATE_RELEASED:
-		wlr_event->state = WLR_BUTTON_RELEASED;
+		wlr_event.state = WLR_BUTTON_RELEASED;
 		break;
 	case LIBINPUT_BUTTON_STATE_PRESSED:
-		wlr_event->state = WLR_BUTTON_PRESSED;
+		wlr_event.state = WLR_BUTTON_PRESSED;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_tool->events.button, wlr_event);
+	wl_signal_emit(&dev->tablet_tool->events.button, &wlr_event);
 }

--- a/backend/libinput/touch.c
+++ b/backend/libinput/touch.c
@@ -23,15 +23,14 @@ void handle_touch_down(struct libinput_event *event,
 	}
 	struct libinput_event_touch *tevent =
 		libinput_event_get_touch_event(event);
-	struct wlr_event_touch_down *wlr_event =
-		calloc(1, sizeof(struct wlr_event_touch_down));
-	wlr_event->time_sec = libinput_event_touch_get_time(tevent);
-	wlr_event->time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event->slot = libinput_event_touch_get_slot(tevent);
-	wlr_event->x_mm = libinput_event_touch_get_x(tevent);
-	wlr_event->y_mm = libinput_event_touch_get_y(tevent);
-	libinput_device_get_size(device, &wlr_event->width_mm, &wlr_event->height_mm);
-	wl_signal_emit(&dev->touch->events.down, wlr_event);
+	struct wlr_event_touch_down wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
+	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
+	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
+	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
+	wl_signal_emit(&dev->touch->events.down, &wlr_event);
 }
 
 void handle_touch_up(struct libinput_event *event,
@@ -44,12 +43,11 @@ void handle_touch_up(struct libinput_event *event,
 	}
 	struct libinput_event_touch *tevent =
 		libinput_event_get_touch_event(event);
-	struct wlr_event_touch_up *wlr_event =
-		calloc(1, sizeof(struct wlr_event_touch_up));
-	wlr_event->time_sec = libinput_event_touch_get_time(tevent);
-	wlr_event->time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event->slot = libinput_event_touch_get_slot(tevent);
-	wl_signal_emit(&dev->touch->events.up, wlr_event);
+	struct wlr_event_touch_up wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
+	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wl_signal_emit(&dev->touch->events.up, &wlr_event);
 }
 
 void handle_touch_motion(struct libinput_event *event,
@@ -62,15 +60,14 @@ void handle_touch_motion(struct libinput_event *event,
 	}
 	struct libinput_event_touch *tevent =
 		libinput_event_get_touch_event(event);
-	struct wlr_event_touch_motion *wlr_event =
-		calloc(1, sizeof(struct wlr_event_touch_motion));
-	wlr_event->time_sec = libinput_event_touch_get_time(tevent);
-	wlr_event->time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event->slot = libinput_event_touch_get_slot(tevent);
-	wlr_event->x_mm = libinput_event_touch_get_x(tevent);
-	wlr_event->y_mm = libinput_event_touch_get_y(tevent);
-	libinput_device_get_size(device, &wlr_event->width_mm, &wlr_event->height_mm);
-	wl_signal_emit(&dev->touch->events.motion, wlr_event);
+	struct wlr_event_touch_motion wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
+	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
+	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
+	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
+	wl_signal_emit(&dev->touch->events.motion, &wlr_event);
 }
 
 void handle_touch_cancel(struct libinput_event *event,
@@ -83,10 +80,9 @@ void handle_touch_cancel(struct libinput_event *event,
 	}
 	struct libinput_event_touch *tevent =
 		libinput_event_get_touch_event(event);
-	struct wlr_event_touch_cancel *wlr_event =
-		calloc(1, sizeof(struct wlr_event_touch_cancel));
-	wlr_event->time_sec = libinput_event_touch_get_time(tevent);
-	wlr_event->time_usec = libinput_event_touch_get_time_usec(tevent);
-	wlr_event->slot = libinput_event_touch_get_slot(tevent);
-	wl_signal_emit(&dev->touch->events.cancel, wlr_event);
+	struct wlr_event_touch_cancel wlr_event = { 0 };
+	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
+	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
+	wlr_event.slot = libinput_event_touch_get_slot(tevent);
+	wl_signal_emit(&dev->touch->events.cancel, &wlr_event);
 }

--- a/backend/udev.c
+++ b/backend/udev.c
@@ -217,6 +217,7 @@ void wlr_udev_destroy(struct wlr_udev *udev) {
 	wl_event_source_remove(udev->event);
 	udev_monitor_unref(udev->mon);
 	udev_unref(udev->udev);
+	free(udev);
 }
 
 bool wlr_udev_signal_add(struct wlr_udev *udev, dev_t dev, struct wl_listener *listener) {

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -171,10 +171,15 @@ bool wlr_output_move_cursor(struct wlr_output *output, int x, int y) {
 }
 
 void wlr_output_destroy(struct wlr_output *output) {
-	if (!output) return;
+	if (!output) {
+		return;
+	}
+
 	output->impl->destroy(output->state);
 	for (size_t i = 0; output->modes && i < output->modes->length; ++i) {
-		free(output->modes->items[i]);
+		struct wlr_output_mode *mode = output->modes->items[i];
+		free(mode->state);
+		free(mode);
 	}
 	list_free(output->modes);
 	free(output);


### PR DESCRIPTION
Three parts:
 - change libinput events to be on the stack. I went for minimal change with wlr_event = { 0 } to replace calloc, compiler should optimize it out for the fields we set right afterwards anyway -- happy to do slightly different.
 - A little bit of cleanup of our destroy functions
 - Still missing something obvious in the example code though, the remove functions are never called. Might use a hint there, not sure what is supposed to trigger these events - should our own code in the libinput backend when we destroy notify every device of a remove event?
I still need to test on a computer where I can actually unplug the mouse (e.g. not a laptop with a trackpad), not sure if it's called on unplugging either at this point...