### PR TITLE
Fix libinput destroy for devices with multiple capabilities

### DIFF
--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -81,15 +81,15 @@ static void wlr_libinput_backend_destroy(struct wlr_backend_state *state) {
 	if (!state) {
 		return;
 	}
-
 	for (size_t i = 0; i < state->devices->length; i++) {
-		struct wlr_input_device *wlr_device = state->devices->items[i];
-
-		wlr_input_device_destroy(wlr_device);
+		list_t *wlr_devices = state->devices->items[i];
+		for (size_t j = 0; j < wlr_devices->length; j++) {
+			wlr_input_device_destroy(wlr_devices->items[j]);
+		}
+		list_free(wlr_devices);
 	}
 	list_free(state->devices);
 	libinput_unref(state->libinput);
-
 	free(state);
 }
 

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -24,11 +24,6 @@ struct wlr_input_device *get_appropriate_device(
 }
 
 static void wlr_libinput_device_destroy(struct wlr_input_device_state *state) {
-	list_t *devices = libinput_device_get_user_data(state->handle);
-	// devices themselves are freed in wlr_libinput_backend_destroy
-	// this list only has a part of the same elements so just free list
-	list_free(devices);
-
 	libinput_device_unref(state->handle);
 	free(state);
 }
@@ -51,7 +46,6 @@ static struct wlr_input_device *allocate_device(
 		type, &input_device_impl, devstate,
 		name, vendor, product);
 	list_add(devices, wlr_device);
-	list_add(state->devices, wlr_device);
 	return wlr_device;
 }
 
@@ -109,6 +103,7 @@ static void handle_device_added(struct wlr_backend_state *state,
 
 	if (devices->length > 0) {
 		libinput_device_set_user_data(device, devices);
+		list_add(state->devices, devices);
 	} else {
 		list_free(devices);
 	}


### PR DESCRIPTION
Didn't find anything better than making state->devices a list of list.

Thanksfully it doesn't seem to be used for anything aside of final free, might mess with it more to handle unplug events but this fixes the crash