### PR TITLE
More leaks

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -104,6 +104,7 @@ static bool init_planes(struct wlr_backend_state *drm) {
 	drm->primary_planes = drm->overlay_planes + drm->num_overlay_planes;
 	drm->cursor_planes = drm->primary_planes + drm->num_primary_planes;
 
+	drmModeFreePlaneResources(plane_res);
 	return true;
 
 error_planes:

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -33,6 +33,7 @@ static int wlr_libinput_readable(int fd, uint32_t mask, void *_state) {
 	struct libinput_event *event;
 	while ((event = libinput_get_event(state->libinput))) {
 		wlr_libinput_event(state, event);
+		libinput_event_destroy(event);
 	}
 	return 0;
 }

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -84,7 +84,9 @@ static void wlr_libinput_backend_destroy(struct wlr_backend_state *state) {
 	for (size_t i = 0; i < state->devices->length; i++) {
 		list_t *wlr_devices = state->devices->items[i];
 		for (size_t j = 0; j < wlr_devices->length; j++) {
-			wlr_input_device_destroy(wlr_devices->items[j]);
+			struct wlr_input_device *wlr_device = wlr_devices->items[j];
+			wl_signal_emit(&state->backend->events.input_remove, wlr_device);
+			wlr_input_device_destroy(wlr_device);
 		}
 		list_free(wlr_devices);
 	}

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -111,8 +111,21 @@ static void handle_device_added(struct wlr_backend_state *state,
 
 static void handle_device_removed(struct wlr_backend_state *state,
 		struct libinput_device *device) {
-	wlr_log(L_DEBUG, "libinput device removed");
-	// TODO
+	list_t *devices = libinput_device_get_user_data(device);
+        for (size_t i = 0; i < devices->length; i++) {
+		struct wlr_input_device *wlr_device = devices->items[i];
+		wlr_log(L_DEBUG, "Removing %s [%d:%d]", wlr_device->name,
+			wlr_device->vendor, wlr_device->product);
+		wl_signal_emit(&state->backend->events.input_remove, wlr_device);
+		wlr_input_device_destroy(wlr_device);
+	}
+	for (size_t i = 0; i < state->devices->length; i++) {
+		if (state->devices->items[i] == devices) {
+			list_del(state->devices, i);
+			break;
+		}
+	}
+	list_free(devices);
 }
 
 void wlr_libinput_event(struct wlr_backend_state *state,

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -85,6 +85,7 @@ static void wlr_wl_backend_destroy(struct wlr_backend_state *state) {
 
 	list_free(state->devices);
 	list_free(state->outputs);
+	free(state->seatName);
 
 	wlr_egl_free(&state->egl);
 	if (state->seat) wl_seat_destroy(state->seat);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -46,6 +46,7 @@ static void wlr_wl_output_transform(struct wlr_output_state *output,
 }
 
 static void wlr_wl_output_destroy(struct wlr_output_state *output) {
+	wl_signal_emit(&output->backend->backend->events.output_remove, output->wlr_output);
 	if(output->frame_callback) wl_callback_destroy(output->frame_callback);
 	eglDestroySurface(output->backend->egl.display, output->surface);
 	wl_egl_window_destroy(output->egl_window);

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -258,6 +258,7 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 static void seat_handle_name(void *data, struct wl_seat *wl_seat, const char *name) {
 	struct wlr_backend_state *state = data;
 	assert(state->seat == wl_seat);
+	// Do we need to check if seatName was previously set for name change?
 	state->seatName = strdup(name);
 }
 

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -169,6 +169,7 @@ static struct wl_keyboard_listener keyboard_listener = {
 };
 
 static void input_device_destroy(struct wlr_input_device_state *state) {
+	wl_signal_emit(&state->backend->backend->events.input_remove, state->wlr_device);
 	if (state->resource)
 		wl_proxy_destroy(state->resource);
 	free(state);
@@ -206,7 +207,7 @@ static struct wlr_input_device *allocate_device(struct wlr_backend_state *state,
 		free(devstate);
 		return NULL;
 	}
-
+	devstate->wlr_device = wlr_device;
 	list_add(state->devices, wlr_device);
 	return wlr_device;
 }

--- a/examples/shared.c
+++ b/examples/shared.c
@@ -384,14 +384,13 @@ static void tablet_pad_remove(struct wlr_input_device *device, struct compositor
 	if (!pstate) {
 		return;
 	}
-	// TODO probably missing more actions
+	wl_list_remove(&pstate->button.link);
 	free(pstate);
 }
 
-// TODO missing something that calls this on teardown
 static void input_remove_notify(struct wl_listener *listener, void *data) {
 	struct wlr_input_device *device = data;
-	struct compositor_state *state = wl_container_of(listener, state, input_add);
+	struct compositor_state *state = wl_container_of(listener, state, input_remove);
 	switch (device->type) {
 	case WLR_INPUT_DEVICE_KEYBOARD:
 		keyboard_remove(device, state);

--- a/examples/shared.c
+++ b/examples/shared.c
@@ -311,6 +311,8 @@ static void keyboard_remove(struct wlr_input_device *device, struct compositor_s
 	if (!kbstate) {
 		return;
 	}
+	xkb_state_unref(kbstate->xkb_state);
+	xkb_map_unref(kbstate->keymap);
 	wl_list_remove(&kbstate->link);
 	wl_list_remove(&kbstate->key.link);
 	free(kbstate);

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -25,7 +25,7 @@ struct wlr_backend_state {
 	struct wl_shell *shell;
 	struct wl_shm *shm;
 	struct wl_seat *seat;
-	const char *seatName;
+	char *seatName;
 };
 
 struct wlr_output_state {

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -33,13 +33,14 @@ struct wlr_output_state {
 	struct wlr_output *wlr_output;
 	struct wl_surface *surface;
 	struct wl_shell_surface *shell_surface;
-	struct wl_egl_window* egl_window;
-	struct wl_callback* frame_callback;
+	struct wl_egl_window *egl_window;
+	struct wl_callback *frame_callback;
 	void *egl_surface;
 };
 
 struct wlr_input_device_state {
-	struct wlr_backend_state* backend;
+	struct wlr_backend_state *backend;
+	struct wlr_input_device *wlr_device;
 	void *resource;
 };
 


### PR DESCRIPTION
With that I think we're finally clean, well, ASAN/valgrind only pick a couple more unreachable regions that I didn't see how to fix (eglGetProcAddress and wl_event_loop_add_fd both allocate something and meh - we're down from 1MB of leak to around a hundred, that'll do)

libinput_event_destroy and the GLES stuff are the two big ones. I'm not too familiar with opengl but some wiki says we should always detach/free after linking, and I make a point of always trusting what I read on the internet.
Might be worth noting that the fragment_src_external program never links for me - but the error doesn't come back all the way up so this doesn't change anything at this point.