### PR TITLE
Fix external shader

### DIFF
--- a/render/gles2/shaders.c
+++ b/render/gles2/shaders.c
@@ -94,9 +94,9 @@ const GLchar fragment_src_rgbx[] =
 const GLchar fragment_src_external[] =
 "#extension GL_OES_EGL_image_external : require\n"
 "precision mediump float;"
+"varying vec2 v_texcoord;"
 "uniform samplerExternalOES texture0;"
-"varying vec2 v_uv;"
 "void main() {"
-"  vec4 col = texture2D(texture0, v_uv);"
+"  vec4 col = texture2D(texture0, v_texcoord);"
 "  gl_FragColor = vec4(col.rgb, col.a);"
 "}";


### PR DESCRIPTION
Some pr in the last days added support for shader compile error messages that revealed the external shader does not link correctly. This fixes it.

We would have noticed it if we could test it somehow but after some research and if i understand everything correctly it seems the external image/shader stuff is only used in some uncommon situations (yuv buffers) so no idea how to test it.