### PR TITLE
libinput: fix segfault when handling non-wlr device removal

### DIFF
--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -112,6 +112,9 @@ static void handle_device_added(struct wlr_backend_state *state,
 static void handle_device_removed(struct wlr_backend_state *state,
 		struct libinput_device *device) {
 	list_t *devices = libinput_device_get_user_data(device);
+	if (!devices) {
+		return;
+	}
         for (size_t i = 0; i < devices->length; i++) {
 		struct wlr_input_device *wlr_device = devices->items[i];
 		wlr_log(L_DEBUG, "Removing %s [%d:%d]", wlr_device->name,


### PR DESCRIPTION
Devices is null for some devices. . . There's way too many things called device or devices in there!