### PR TITLE
Libinput renaming

### DIFF
--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -112,13 +112,15 @@ static void handle_device_added(struct wlr_libinput_backend *backend,
 static void handle_device_removed(struct wlr_libinput_backend *backend,
 		struct libinput_device *device) {
 	list_t *devices = libinput_device_get_user_data(device);
+	int vendor = libinput_device_get_id_vendor(device);
+	int product = libinput_device_get_id_product(device);
+	const char *name = libinput_device_get_name(device);
+	wlr_log(L_DEBUG, "Removing %s [%d:%d]", name, vendor, product);
 	if (!devices) {
 		return;
 	}
 	for (size_t i = 0; i < devices->length; i++) {
 		struct wlr_input_device *wlr_device = devices->items[i];
-		wlr_log(L_DEBUG, "Removing %s [%d:%d]", wlr_device->name,
-			wlr_device->vendor, wlr_device->product);
 		wl_signal_emit(&backend->backend.events.input_remove, wlr_device);
 		wlr_input_device_destroy(wlr_device);
 	}

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -9,13 +9,13 @@
 
 struct wlr_input_device *get_appropriate_device(
 		enum wlr_input_device_type desired_type,
-		struct libinput_device *device) {
-	list_t *devices = libinput_device_get_user_data(device);
-	if (!devices) {
+		struct libinput_device *libinput_dev) {
+	list_t *wlr_devices = libinput_device_get_user_data(libinput_dev);
+	if (!wlr_devices) {
 		return NULL;
 	}
-	for (size_t i = 0; i < devices->length; ++i) {
-		struct wlr_input_device *dev = devices->items[i];
+	for (size_t i = 0; i < wlr_devices->length; ++i) {
+		struct wlr_input_device *dev = wlr_devices->items[i];
 		if (dev->type == desired_type) {
 			return dev;
 		}
@@ -33,168 +33,168 @@ static struct wlr_input_device_impl input_device_impl = {
 };
 
 static struct wlr_input_device *allocate_device(
-		struct wlr_libinput_backend *backend, struct libinput_device *device,
-		list_t *devices, enum wlr_input_device_type type) {
-	int vendor = libinput_device_get_id_vendor(device);
-	int product = libinput_device_get_id_product(device);
-	const char *name = libinput_device_get_name(device);
+		struct wlr_libinput_backend *backend, struct libinput_device *libinput_dev,
+		list_t *wlr_devices, enum wlr_input_device_type type) {
+	int vendor = libinput_device_get_id_vendor(libinput_dev);
+	int product = libinput_device_get_id_product(libinput_dev);
+	const char *name = libinput_device_get_name(libinput_dev);
 	struct wlr_input_device_state *devstate =
 		calloc(1, sizeof(struct wlr_input_device_state));
-	devstate->handle = device;
-	libinput_device_ref(device);
-	struct wlr_input_device *wlr_device = wlr_input_device_create(
+	devstate->handle = libinput_dev;
+	libinput_device_ref(libinput_dev);
+	struct wlr_input_device *wlr_dev = wlr_input_device_create(
 		type, &input_device_impl, devstate,
 		name, vendor, product);
-	list_add(devices, wlr_device);
-	return wlr_device;
+	list_add(wlr_devices, wlr_dev);
+	return wlr_dev;
 }
 
 static void handle_device_added(struct wlr_libinput_backend *backend,
-		struct libinput_device *device) {
-	assert(backend && device);
+		struct libinput_device *libinput_dev) {
+	assert(backend && libinput_dev);
 	/*
 	 * Note: the wlr API exposes only devices with a single capability, because
 	 * that meshes better with how Wayland does things and is a bit simpler.
 	 * However, libinput devices often have multiple capabilities - in such
 	 * cases we have to create several devices.
 	 */
-	int vendor = libinput_device_get_id_vendor(device);
-	int product = libinput_device_get_id_product(device);
-	const char *name = libinput_device_get_name(device);
-	list_t *devices = list_create();
+	int vendor = libinput_device_get_id_vendor(libinput_dev);
+	int product = libinput_device_get_id_product(libinput_dev);
+	const char *name = libinput_device_get_name(libinput_dev);
+	list_t *wlr_devices = list_create();
 	wlr_log(L_DEBUG, "Added %s [%d:%d]", name, vendor, product);
 
-	if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_KEYBOARD)) {
-		struct wlr_input_device *wlr_device = allocate_device(backend,
-				device, devices, WLR_INPUT_DEVICE_KEYBOARD);
-		wlr_device->keyboard = wlr_libinput_keyboard_create(device);
-		wl_signal_emit(&backend->backend.events.input_add, wlr_device);
+	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_KEYBOARD)) {
+		struct wlr_input_device *wlr_dev = allocate_device(backend,
+				libinput_dev, wlr_devices, WLR_INPUT_DEVICE_KEYBOARD);
+		wlr_dev->keyboard = wlr_libinput_keyboard_create(libinput_dev);
+		wl_signal_emit(&backend->backend.events.input_add, wlr_dev);
 	}
-	if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_POINTER)) {
-		struct wlr_input_device *wlr_device = allocate_device(backend,
-				device, devices, WLR_INPUT_DEVICE_POINTER);
-		wlr_device->pointer = wlr_libinput_pointer_create(device);
-		wl_signal_emit(&backend->backend.events.input_add, wlr_device);
+	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_POINTER)) {
+		struct wlr_input_device *wlr_dev = allocate_device(backend,
+				libinput_dev, wlr_devices, WLR_INPUT_DEVICE_POINTER);
+		wlr_dev->pointer = wlr_libinput_pointer_create(libinput_dev);
+		wl_signal_emit(&backend->backend.events.input_add, wlr_dev);
 	}
-	if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_TOUCH)) {
-		struct wlr_input_device *wlr_device = allocate_device(backend,
-				device, devices, WLR_INPUT_DEVICE_TOUCH);
-		wlr_device->touch = wlr_libinput_touch_create(device);
-		wl_signal_emit(&backend->backend.events.input_add, wlr_device);
+	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_TOUCH)) {
+		struct wlr_input_device *wlr_dev = allocate_device(backend,
+				libinput_dev, wlr_devices, WLR_INPUT_DEVICE_TOUCH);
+		wlr_dev->touch = wlr_libinput_touch_create(libinput_dev);
+		wl_signal_emit(&backend->backend.events.input_add, wlr_dev);
 	}
-	if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_TABLET_TOOL)) {
-		struct wlr_input_device *wlr_device = allocate_device(backend,
-				device, devices, WLR_INPUT_DEVICE_TABLET_TOOL);
-		wlr_device->tablet_tool = wlr_libinput_tablet_tool_create(device);
-		wl_signal_emit(&backend->backend.events.input_add, wlr_device);
+	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_TABLET_TOOL)) {
+		struct wlr_input_device *wlr_dev = allocate_device(backend,
+				libinput_dev, wlr_devices, WLR_INPUT_DEVICE_TABLET_TOOL);
+		wlr_dev->tablet_tool = wlr_libinput_tablet_tool_create(libinput_dev);
+		wl_signal_emit(&backend->backend.events.input_add, wlr_dev);
 	}
-	if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_TABLET_PAD)) {
-		struct wlr_input_device *wlr_device = allocate_device(backend,
-				device, devices, WLR_INPUT_DEVICE_TABLET_PAD);
-		wlr_device->tablet_pad = wlr_libinput_tablet_pad_create(device);
-		wl_signal_emit(&backend->backend.events.input_add, wlr_device);
+	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_TABLET_PAD)) {
+		struct wlr_input_device *wlr_dev = allocate_device(backend,
+				libinput_dev, wlr_devices, WLR_INPUT_DEVICE_TABLET_PAD);
+		wlr_dev->tablet_pad = wlr_libinput_tablet_pad_create(libinput_dev);
+		wl_signal_emit(&backend->backend.events.input_add, wlr_dev);
 	}
-	if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_GESTURE)) {
+	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_GESTURE)) {
 		// TODO
 	}
-	if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_SWITCH)) {
+	if (libinput_device_has_capability(libinput_dev, LIBINPUT_DEVICE_CAP_SWITCH)) {
 		// TODO
 	}
 
-	if (devices->length > 0) {
-		libinput_device_set_user_data(device, devices);
-		list_add(backend->devices, devices);
+	if (wlr_devices->length > 0) {
+		libinput_device_set_user_data(libinput_dev, wlr_devices);
+		list_add(backend->wlr_device_lists, wlr_devices);
 	} else {
-		list_free(devices);
+		list_free(wlr_devices);
 	}
 }
 
 static void handle_device_removed(struct wlr_libinput_backend *backend,
-		struct libinput_device *device) {
-	list_t *devices = libinput_device_get_user_data(device);
-	int vendor = libinput_device_get_id_vendor(device);
-	int product = libinput_device_get_id_product(device);
-	const char *name = libinput_device_get_name(device);
+		struct libinput_device *libinput_dev) {
+	list_t *wlr_devices = libinput_device_get_user_data(libinput_dev);
+	int vendor = libinput_device_get_id_vendor(libinput_dev);
+	int product = libinput_device_get_id_product(libinput_dev);
+	const char *name = libinput_device_get_name(libinput_dev);
 	wlr_log(L_DEBUG, "Removing %s [%d:%d]", name, vendor, product);
-	if (!devices) {
+	if (!wlr_devices) {
 		return;
 	}
-	for (size_t i = 0; i < devices->length; i++) {
-		struct wlr_input_device *wlr_device = devices->items[i];
-		wl_signal_emit(&backend->backend.events.input_remove, wlr_device);
-		wlr_input_device_destroy(wlr_device);
+        for (size_t i = 0; i < wlr_devices->length; i++) {
+		struct wlr_input_device *wlr_dev = wlr_devices->items[i];
+		wl_signal_emit(&backend->backend.events.input_remove, wlr_dev);
+		wlr_input_device_destroy(wlr_dev);
 	}
-	for (size_t i = 0; i < backend->devices->length; i++) {
-		if (backend->devices->items[i] == devices) {
-			list_del(backend->devices, i);
+	for (size_t i = 0; i < backend->wlr_device_lists->length; i++) {
+		if (backend->wlr_device_lists->items[i] == wlr_devices) {
+			list_del(backend->wlr_device_lists, i);
 			break;
 		}
 	}
-	list_free(devices);
+	list_free(wlr_devices);
 }
 
 void wlr_libinput_event(struct wlr_libinput_backend *backend,
 		struct libinput_event *event) {
 	assert(backend && event);
-	struct libinput_device *device = libinput_event_get_device(event);
+	struct libinput_device *libinput_dev = libinput_event_get_device(event);
 	enum libinput_event_type event_type = libinput_event_get_type(event);
 	switch (event_type) {
 	case LIBINPUT_EVENT_DEVICE_ADDED:
-		handle_device_added(backend, device);
+		handle_device_added(backend, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_DEVICE_REMOVED:
-		handle_device_removed(backend, device);
+		handle_device_removed(backend, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_KEYBOARD_KEY:
-		handle_keyboard_key(event, device);
+		handle_keyboard_key(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_POINTER_MOTION:
-		handle_pointer_motion(event, device);
+		handle_pointer_motion(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE:
-		handle_pointer_motion_abs(event, device);
+		handle_pointer_motion_abs(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_POINTER_BUTTON:
-		handle_pointer_button(event, device);
+		handle_pointer_button(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_POINTER_AXIS:
-		handle_pointer_axis(event, device);
+		handle_pointer_axis(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TOUCH_DOWN:
-		handle_touch_down(event, device);
+		handle_touch_down(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TOUCH_UP:
-		handle_touch_up(event, device);
+		handle_touch_up(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TOUCH_MOTION:
-		handle_touch_motion(event, device);
+		handle_touch_motion(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TOUCH_CANCEL:
-		handle_touch_cancel(event, device);
+		handle_touch_cancel(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TOUCH_FRAME:
 		// no-op (at least for now)
 		break;
 	case LIBINPUT_EVENT_TABLET_TOOL_AXIS:
-		handle_tablet_tool_axis(event, device);
+		handle_tablet_tool_axis(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY:
-		handle_tablet_tool_proximity(event, device);
+		handle_tablet_tool_proximity(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TABLET_TOOL_TIP:
-		handle_tablet_tool_tip(event, device);
+		handle_tablet_tool_tip(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TABLET_TOOL_BUTTON:
-		handle_tablet_tool_button(event, device);
+		handle_tablet_tool_button(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TABLET_PAD_BUTTON:
-		handle_tablet_pad_button(event, device);
+		handle_tablet_pad_button(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TABLET_PAD_RING:
-		handle_tablet_pad_ring(event, device);
+		handle_tablet_pad_ring(event, libinput_dev);
 		break;
 	case LIBINPUT_EVENT_TABLET_PAD_STRIP:
-		handle_tablet_pad_strip(event, device);
+		handle_tablet_pad_strip(event, libinput_dev);
 		break;
 	default:
 		wlr_log(L_DEBUG, "Unknown libinput event %d", event_type);

--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -134,10 +134,8 @@ static void handle_device_removed(struct wlr_libinput_backend *backend,
 void wlr_libinput_event(struct wlr_libinput_backend *backend,
 		struct libinput_event *event) {
 	assert(backend && event);
-	struct libinput *context = libinput_event_get_context(event);
 	struct libinput_device *device = libinput_event_get_device(event);
 	enum libinput_event_type event_type = libinput_event_get_type(event);
-	(void)context;
 	switch (event_type) {
 	case LIBINPUT_EVENT_DEVICE_ADDED:
 		handle_device_added(backend, device);

--- a/backend/libinput/keyboard.c
+++ b/backend/libinput/keyboard.c
@@ -8,15 +8,15 @@
 #include "backend/libinput.h"
 
 struct wlr_keyboard_state {
-	struct libinput_device *device;
+	struct libinput_device *libinput_dev;
 };
 
 static void wlr_libinput_keyboard_set_leds(struct wlr_keyboard_state *kbstate, uint32_t leds) {
-	libinput_device_led_update(kbstate->device, leds);
+	libinput_device_led_update(kbstate->libinput_dev, leds);
 }
 
 static void wlr_libinput_keyboard_destroy(struct wlr_keyboard_state *kbstate) {
-	libinput_device_unref(kbstate->device);
+	libinput_device_unref(kbstate->libinput_dev);
 	free(kbstate);
 }
 
@@ -26,20 +26,20 @@ struct wlr_keyboard_impl impl = {
 };
 
 struct wlr_keyboard *wlr_libinput_keyboard_create(
-		struct libinput_device *device) {
-	assert(device);
+		struct libinput_device *libinput_dev) {
+	assert(libinput_dev);
 	struct wlr_keyboard_state *kbstate = calloc(1, sizeof(struct wlr_keyboard_state));
-	kbstate->device = device;
-	libinput_device_ref(device);
-	libinput_device_led_update(device, 0);
+	kbstate->libinput_dev = libinput_dev;
+	libinput_device_ref(libinput_dev);
+	libinput_device_led_update(libinput_dev, 0);
 	return wlr_keyboard_create(&impl, kbstate);
 }
 
 void handle_keyboard_key(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_KEYBOARD, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_KEYBOARD, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a keyboard event for a device with no keyboards?");
 		return;
 	}
@@ -59,5 +59,5 @@ void handle_keyboard_key(struct libinput_event *event,
 		wlr_event.state = WLR_KEY_PRESSED;
 		break;
 	}
-	wl_signal_emit(&dev->keyboard->events.key, &wlr_event);
+	wl_signal_emit(&wlr_dev->keyboard->events.key, &wlr_event);
 }

--- a/backend/libinput/pointer.c
+++ b/backend/libinput/pointer.c
@@ -8,16 +8,16 @@
 #include "backend/libinput.h"
 
 struct wlr_pointer *wlr_libinput_pointer_create(
-		struct libinput_device *device) {
-	assert(device);
+		struct libinput_device *libinput_dev) {
+	assert(libinput_dev);
 	return wlr_pointer_create(NULL, NULL);
 }
 
 void handle_pointer_motion(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a pointer event for a device with no pointers?");
 		return;
 	}
@@ -28,14 +28,14 @@ void handle_pointer_motion(struct libinput_event *event,
 	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
 	wlr_event.delta_x = libinput_event_pointer_get_dx(pevent);
 	wlr_event.delta_y = libinput_event_pointer_get_dy(pevent);
-	wl_signal_emit(&dev->pointer->events.motion, &wlr_event);
+	wl_signal_emit(&wlr_dev->pointer->events.motion, &wlr_event);
 }
 
 void handle_pointer_motion_abs(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a pointer event for a device with no pointers?");
 		return;
 	}
@@ -46,15 +46,15 @@ void handle_pointer_motion_abs(struct libinput_event *event,
 	wlr_event.time_usec = libinput_event_pointer_get_time_usec(pevent);
 	wlr_event.x_mm = libinput_event_pointer_get_absolute_x(pevent);
 	wlr_event.y_mm = libinput_event_pointer_get_absolute_y(pevent);
-	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
-	wl_signal_emit(&dev->pointer->events.motion_absolute, &wlr_event);
+	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
+	wl_signal_emit(&wlr_dev->pointer->events.motion_absolute, &wlr_event);
 }
 
 void handle_pointer_button(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a pointer event for a device with no pointers?");
 		return;
 	}
@@ -72,14 +72,14 @@ void handle_pointer_button(struct libinput_event *event,
 		wlr_event.state = WLR_BUTTON_RELEASED;
 		break;
 	}
-	wl_signal_emit(&dev->pointer->events.button, &wlr_event);
+	wl_signal_emit(&wlr_dev->pointer->events.button, &wlr_event);
 }
 
 void handle_pointer_axis(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_POINTER, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a pointer event for a device with no pointers?");
 		return;
 	}
@@ -119,6 +119,6 @@ void handle_pointer_axis(struct libinput_event *event,
 			wlr_event.delta = libinput_event_pointer_get_axis_value(
 					pevent, axies[i]);
 		}
-		wl_signal_emit(&dev->pointer->events.axis, &wlr_event);
+		wl_signal_emit(&wlr_dev->pointer->events.axis, &wlr_event);
 	}
 }

--- a/backend/libinput/tablet_pad.c
+++ b/backend/libinput/tablet_pad.c
@@ -8,16 +8,16 @@
 #include "backend/libinput.h"
 
 struct wlr_tablet_pad *wlr_libinput_tablet_pad_create(
-		struct libinput_device *device) {
-	assert(device);
+		struct libinput_device *libinput_dev) {
+	assert(libinput_dev);
 	return wlr_tablet_pad_create(NULL, NULL);
 }
 
 void handle_tablet_pad_button(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_PAD, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_PAD, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a tablet pad event for a device with no tablet pad?");
 		return;
 	}
@@ -35,14 +35,14 @@ void handle_tablet_pad_button(struct libinput_event *event,
 		wlr_event.state = WLR_BUTTON_RELEASED;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_pad->events.button, &wlr_event);
+	wl_signal_emit(&wlr_dev->tablet_pad->events.button, &wlr_event);
 }
 
 void handle_tablet_pad_ring(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_PAD, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_PAD, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a tablet pad event for a device with no tablet pad?");
 		return;
 	}
@@ -61,14 +61,14 @@ void handle_tablet_pad_ring(struct libinput_event *event,
 		wlr_event.source = WLR_TABLET_PAD_RING_SOURCE_FINGER;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_pad->events.ring, &wlr_event);
+	wl_signal_emit(&wlr_dev->tablet_pad->events.ring, &wlr_event);
 }
 
 void handle_tablet_pad_strip(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_PAD, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_PAD, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a tablet pad event for a device with no tablet pad?");
 		return;
 	}
@@ -87,5 +87,5 @@ void handle_tablet_pad_strip(struct libinput_event *event,
 		wlr_event.source = WLR_TABLET_PAD_STRIP_SOURCE_FINGER;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_pad->events.strip, &wlr_event);
+	wl_signal_emit(&wlr_dev->tablet_pad->events.strip, &wlr_event);
 }

--- a/backend/libinput/tablet_tool.c
+++ b/backend/libinput/tablet_tool.c
@@ -8,16 +8,16 @@
 #include "backend/libinput.h"
 
 struct wlr_tablet_tool *wlr_libinput_tablet_tool_create(
-		struct libinput_device *device) {
-	assert(device);
+		struct libinput_device *libinput_dev) {
+	assert(libinput_dev);
 	return wlr_tablet_tool_create(NULL, NULL);
 }
 
 void handle_tablet_tool_axis(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a tablet tool event for a device with no tablet tools?");
 		return;
 	}
@@ -26,7 +26,7 @@ void handle_tablet_tool_axis(struct libinput_event *event,
 	struct wlr_event_tablet_tool_axis wlr_event = { 0 };
 	wlr_event.time_sec = libinput_event_tablet_tool_get_time(tevent);
 	wlr_event.time_usec = libinput_event_tablet_tool_get_time_usec(tevent);
-	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
+	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
 	if (libinput_event_tablet_tool_x_has_changed(tevent)) {
 		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_X;
 		wlr_event.x_mm = libinput_event_tablet_tool_get_x(tevent);
@@ -63,14 +63,14 @@ void handle_tablet_tool_axis(struct libinput_event *event,
 		wlr_event.updated_axes |= WLR_TABLET_TOOL_AXIS_WHEEL;
 		wlr_event.wheel_delta = libinput_event_tablet_tool_get_wheel_delta(tevent);
 	}
-	wl_signal_emit(&dev->tablet_tool->events.axis, &wlr_event);
+	wl_signal_emit(&wlr_dev->tablet_tool->events.axis, &wlr_event);
 }
 
 void handle_tablet_tool_proximity(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a tablet tool event for a device with no tablet tools?");
 		return;
 	}
@@ -85,21 +85,21 @@ void handle_tablet_tool_proximity(struct libinput_event *event,
 		break;
 	case LIBINPUT_TABLET_TOOL_PROXIMITY_STATE_IN:
 		wlr_event.state = WLR_TABLET_TOOL_PROXIMITY_IN;
-		handle_tablet_tool_axis(event, device);
+		handle_tablet_tool_axis(event, libinput_dev);
 		break;
 	}
-	wl_signal_emit(&dev->tablet_tool->events.proximity, &wlr_event);
+	wl_signal_emit(&wlr_dev->tablet_tool->events.proximity, &wlr_event);
 }
 
 void handle_tablet_tool_tip(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a tablet tool event for a device with no tablet tools?");
 		return;
 	}
-	handle_tablet_tool_axis(event, device);
+	handle_tablet_tool_axis(event, libinput_dev);
 	struct libinput_event_tablet_tool *tevent =
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_tip wlr_event = { 0 };
@@ -113,18 +113,18 @@ void handle_tablet_tool_tip(struct libinput_event *event,
 		wlr_event.state = WLR_TABLET_TOOL_TIP_DOWN;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_tool->events.tip, &wlr_event);
+	wl_signal_emit(&wlr_dev->tablet_tool->events.tip, &wlr_event);
 }
 
 void handle_tablet_tool_button(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TABLET_TOOL, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a tablet tool event for a device with no tablet tools?");
 		return;
 	}
-	handle_tablet_tool_axis(event, device);
+	handle_tablet_tool_axis(event, libinput_dev);
 	struct libinput_event_tablet_tool *tevent =
 		libinput_event_get_tablet_tool_event(event);
 	struct wlr_event_tablet_tool_button wlr_event = { 0 };
@@ -139,5 +139,5 @@ void handle_tablet_tool_button(struct libinput_event *event,
 		wlr_event.state = WLR_BUTTON_PRESSED;
 		break;
 	}
-	wl_signal_emit(&dev->tablet_tool->events.button, &wlr_event);
+	wl_signal_emit(&wlr_dev->tablet_tool->events.button, &wlr_event);
 }

--- a/backend/libinput/touch.c
+++ b/backend/libinput/touch.c
@@ -8,16 +8,16 @@
 #include "backend/libinput.h"
 
 struct wlr_touch *wlr_libinput_touch_create(
-		struct libinput_device *device) {
-	assert(device);
+		struct libinput_device *libinput_dev) {
+	assert(libinput_dev);
 	return wlr_touch_create(NULL, NULL);
 }
 
 void handle_touch_down(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a touch event for a device with no touch?");
 		return;
 	}
@@ -29,15 +29,15 @@ void handle_touch_down(struct libinput_event *event,
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
-	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
-	wl_signal_emit(&dev->touch->events.down, &wlr_event);
+	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
+	wl_signal_emit(&wlr_dev->touch->events.down, &wlr_event);
 }
 
 void handle_touch_up(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a touch event for a device with no touch?");
 		return;
 	}
@@ -47,14 +47,14 @@ void handle_touch_up(struct libinput_event *event,
 	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
 	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
-	wl_signal_emit(&dev->touch->events.up, &wlr_event);
+	wl_signal_emit(&wlr_dev->touch->events.up, &wlr_event);
 }
 
 void handle_touch_motion(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a touch event for a device with no touch?");
 		return;
 	}
@@ -66,15 +66,15 @@ void handle_touch_motion(struct libinput_event *event,
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
 	wlr_event.x_mm = libinput_event_touch_get_x(tevent);
 	wlr_event.y_mm = libinput_event_touch_get_y(tevent);
-	libinput_device_get_size(device, &wlr_event.width_mm, &wlr_event.height_mm);
-	wl_signal_emit(&dev->touch->events.motion, &wlr_event);
+	libinput_device_get_size(libinput_dev, &wlr_event.width_mm, &wlr_event.height_mm);
+	wl_signal_emit(&wlr_dev->touch->events.motion, &wlr_event);
 }
 
 void handle_touch_cancel(struct libinput_event *event,
-		struct libinput_device *device) {
-	struct wlr_input_device *dev =
-		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, device);
-	if (!dev) {
+		struct libinput_device *libinput_dev) {
+	struct wlr_input_device *wlr_dev =
+		get_appropriate_device(WLR_INPUT_DEVICE_TOUCH, libinput_dev);
+	if (!wlr_dev) {
 		wlr_log(L_DEBUG, "Got a touch event for a device with no touch?");
 		return;
 	}
@@ -84,5 +84,5 @@ void handle_touch_cancel(struct libinput_event *event,
 	wlr_event.time_sec = libinput_event_touch_get_time(tevent);
 	wlr_event.time_usec = libinput_event_touch_get_time_usec(tevent);
 	wlr_event.slot = libinput_event_touch_get_slot(tevent);
-	wl_signal_emit(&dev->touch->events.cancel, &wlr_event);
+	wl_signal_emit(&wlr_dev->touch->events.cancel, &wlr_event);
 }

--- a/include/backend/libinput.h
+++ b/include/backend/libinput.h
@@ -14,12 +14,12 @@ struct wlr_libinput_backend {
 	struct wlr_udev *udev;
 	struct wl_display *display;
 
-	struct libinput *libinput;
+	struct libinput *libinput_context;
 	struct wl_event_source *input_event;
 
 	struct wl_listener session_signal;
 
-	list_t *devices;
+	list_t *wlr_device_lists;
 };
 
 struct wlr_input_device_state {


### PR DESCRIPTION
You said feel free, so here it is! Hopefully won't get too much in the way of anyone, might be a pain if they have changes pending in libinput.

Also sneaked in a change that makes wayland backend not hog CPU needlessly, happy to resubmit that separately if you think it is worth discussing.

copy/paste from commit message for summary:
    - backend state's 'libinput' to li_context
    - libinput_device ('device') to li_dev
    - wlr_device ('dev') to wlr_dev
    - 'devices' lists tangling of libinput devices to wlr_devices
    - 'devices' list of wlr_devices in backend state to wlr_device_lists