### PR TITLE
Implement wayland backend cursor

### DIFF
--- a/backend/meson.build
+++ b/backend/meson.build
@@ -22,6 +22,7 @@ backend_files = files(
   'wayland/output.c',
   'wayland/registry.c',
   'wayland/wl_seat.c',
+  'wayland/os-compatibility.c',
 )
 
 if systemd.found()

--- a/backend/wayland/os-compatibility.c
+++ b/backend/wayland/os-compatibility.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2012 Collabora, Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define _XOPEN_SOURCE 700
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/epoll.h>
+#include <string.h>
+#include <stdlib.h>
+
+int
+os_fd_set_cloexec(int fd)
+{
+	long flags;
+
+	if (fd == -1)
+		return -1;
+
+	flags = fcntl(fd, F_GETFD);
+	if (flags == -1)
+		return -1;
+
+	if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1)
+		return -1;
+
+	return 0;
+}
+
+static int
+set_cloexec_or_close(int fd)
+{
+	if (os_fd_set_cloexec(fd) != 0) {
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+static int
+create_tmpfile_cloexec(char *tmpname)
+{
+	int fd;
+
+#ifdef HAVE_MKOSTEMP
+	fd = mkostemp(tmpname, O_CLOEXEC);
+	if (fd >= 0)
+		unlink(tmpname);
+#else
+	fd = mkstemp(tmpname);
+	if (fd >= 0) {
+		fd = set_cloexec_or_close(fd);
+		unlink(tmpname);
+	}
+#endif
+
+	return fd;
+}
+
+/*
+ * Create a new, unique, anonymous file of the given size, and
+ * return the file descriptor for it. The file descriptor is set
+ * CLOEXEC. The file is immediately suitable for mmap()'ing
+ * the given size at offset zero.
+ *
+ * The file should not have a permanent backing store like a disk,
+ * but may have if XDG_RUNTIME_DIR is not properly implemented in OS.
+ *
+ * The file name is deleted from the file system.
+ *
+ * The file is suitable for buffer sharing between processes by
+ * transmitting the file descriptor over Unix sockets using the
+ * SCM_RIGHTS methods.
+ *
+ * If the C library implements posix_fallocate(), it is used to
+ * guarantee that disk space is available for the file at the
+ * given size. If disk space is insufficient, errno is set to ENOSPC.
+ * If posix_fallocate() is not supported, program may receive
+ * SIGBUS on accessing mmap()'ed file contents instead.
+ */
+int
+os_create_anonymous_file(off_t size)
+{
+	static const char template[] = "/wlroots-shared-XXXXXX";
+	const char *path;
+	char *name;
+	int fd;
+	int ret;
+
+	path = getenv("XDG_RUNTIME_DIR");
+	if (!path) {
+		errno = ENOENT;
+		return -1;
+	}
+
+	name = malloc(strlen(path) + sizeof(template));
+	if (!name)
+		return -1;
+
+	strcpy(name, path);
+	strcat(name, template);
+
+	fd = create_tmpfile_cloexec(name);
+
+	free(name);
+
+	if (fd < 0)
+		return -1;
+
+#ifdef HAVE_POSIX_FALLOCATE
+	do {
+		ret = posix_fallocate(fd, 0, size);
+	} while (ret == EINTR);
+	if (ret != 0) {
+		close(fd);
+		errno = ret;
+		return -1;
+	}
+#else
+	do {
+		ret = ftruncate(fd, size);
+	} while (ret < 0 && errno == EINTR);
+	if (ret < 0) {
+		close(fd);
+		return -1;
+	}
+#endif
+
+	return fd;
+}

--- a/include/backend/wayland.h
+++ b/include/backend/wayland.h
@@ -27,6 +27,7 @@ struct wlr_wl_backend {
 	struct wl_shell *shell;
 	struct wl_shm *shm;
 	struct wl_seat *seat;
+	struct wl_pointer *pointer;
 	char *seat_name;
 };
 
@@ -38,6 +39,14 @@ struct wlr_wl_backend_output {
 	struct wl_shell_surface *shell_surface;
 	struct wl_egl_window *egl_window;
 	struct wl_callback *frame_callback;
+
+	struct wl_shm_pool *cursor_pool;
+	void *cursor_buffer; // actually a (client-side) struct wl_buffer*
+	uint8_t *cursor_data;
+	struct wl_surface *cursor_surface;
+	uint32_t cursor_buf_size;
+	uint32_t enter_serial;
+
 	void *egl_surface;
 };
 
@@ -55,6 +64,7 @@ struct wlr_wl_pointer {
 };
 
 void wlr_wl_registry_poll(struct wlr_wl_backend *backend);
+void wlr_wl_output_update_cursor(struct wlr_wl_backend_output *output, uint32_t serial);
 struct wlr_wl_backend_output *wlr_wl_output_for_surface(
 		struct wlr_wl_backend *backend, struct wl_surface *surface);
 


### PR DESCRIPTION
Branched this off the style issue fix branch by accident, can rebase it as soon as that is merged.
Tested on weston and sway. Had to add os-compatibility.c for the shm buffer (stripped everything unneeded).

There is one (minor) issue, i had to use a void* instead of wl_buffer* in the wlr_wl_backend_output since otherwise the compiler warns (and therefore errors) about wl_buffer being deprecated (since there are wl_buffer structs in the client and server side, deprecated on server side, we actually refer to the client side definition here...). Not sure if this is a problem or if it can be handled better.
Resolves #46.