### PR TITLE
Move wl_shell into wlroots

### DIFF
--- a/examples/compositor.h
+++ b/examples/compositor.h
@@ -17,24 +17,4 @@ void wl_compositor_init(struct wl_display *display,
 struct wlr_surface;
 void wl_compositor_surface_destroyed(struct wl_compositor_state *compositor,
 		struct wlr_surface *surface);
-
-struct wl_shell_state {
-	struct wl_global *wl_global;
-	struct wl_list wl_resources;
-};
-
-struct xdg_shell_state {
-	struct wl_global *wl_global;
-	struct wl_list wl_resources;
-	struct wl_display *display;
-};
-
-void wl_shell_init(struct wl_display *display,
-		struct wl_shell_state *state);
-
-void xdg_shell_init(struct wl_display *display,
-		struct xdg_shell_state *state);
-
-void xdg_shell_release(struct xdg_shell_state *state);
-
 #endif

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -22,7 +22,7 @@
 struct sample_state {
 	struct wlr_renderer *renderer;
 	struct wl_compositor_state compositor;
-	struct wlr_wl_shell wl_shell;
+	struct wlr_wl_shell *wl_shell;
 	struct wlr_xdg_shell_v6 *xdg_shell;
 };
 
@@ -62,7 +62,7 @@ void handle_output_frame(struct output_state *output, struct timespec *ts) {
 	wlr_renderer_begin(sample->renderer, wlr_output);
 
 	struct wlr_wl_shell_surface *wl_shell_surface;
-	wl_list_for_each(wl_shell_surface, &sample->wl_shell.surfaces, link) {
+	wl_list_for_each(wl_shell_surface, &sample->wl_shell->surfaces, link) {
 		output_frame_handle_surface(sample, wlr_output, ts, wl_shell_surface->surface);
 	}
 	struct wlr_xdg_surface_v6 *xdg_surface;
@@ -85,8 +85,11 @@ int main() {
 	state.renderer = wlr_gles2_renderer_init(compositor.backend);
 	wl_display_init_shm(compositor.display);
 	wl_compositor_init(compositor.display, &state.compositor, state.renderer);
-	wlr_wl_shell_init(&state.wl_shell, compositor.display);
-	state.xdg_shell = wlr_xdg_shell_v6_init(compositor.display);
+	state.wl_shell = wlr_wl_shell_create(compositor.display);
+	state.xdg_shell = wlr_xdg_shell_v6_create(compositor.display);
 
 	compositor_run(&compositor);
+
+	wlr_wl_shell_destroy(state.wl_shell);
+	wlr_xdg_shell_v6_destroy(state.xdg_shell);
 }

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -12,6 +12,7 @@
 #include <wlr/render/gles2.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_surface.h>
+#include <wlr/types/wlr_wl_shell.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <xkbcommon/xkbcommon.h>
 #include <wlr/util/log.h>
@@ -21,7 +22,7 @@
 struct sample_state {
 	struct wlr_renderer *renderer;
 	struct wl_compositor_state compositor;
-	struct wl_shell_state shell;
+	struct wlr_wl_shell wl_shell;
 	struct wlr_xdg_shell_v6 *xdg_shell;
 };
 
@@ -75,7 +76,7 @@ int main() {
 	state.renderer = wlr_gles2_renderer_init(compositor.backend);
 	wl_display_init_shm(compositor.display);
 	wl_compositor_init(compositor.display, &state.compositor, state.renderer);
-	wl_shell_init(compositor.display, &state.shell);
+	wlr_wl_shell_init(&state.wl_shell, compositor.display);
 	state.xdg_shell = wlr_xdg_shell_v6_init(compositor.display);
 
 	compositor_run(&compositor);

--- a/examples/compositor/wl_compositor.c
+++ b/examples/compositor/wl_compositor.c
@@ -9,11 +9,12 @@
 static void destroy_surface_listener(struct wl_listener *listener, void *data) {
 	struct wlr_surface *surface = wl_resource_get_user_data(data);
 	struct wl_compositor_state *state = surface->compositor_data;
+	assert(data == surface->resource);
 
 	struct wl_resource *res = NULL;
 	wl_list_for_each(res, &state->surfaces, link) {
 		if (res == surface->resource) {
-			wl_list_remove(&res->link);
+			wl_list_remove(wl_resource_get_link(res));
 			break;
 		}
 	}

--- a/examples/compositor/wl_compositor.c
+++ b/examples/compositor/wl_compositor.c
@@ -7,17 +7,7 @@
 #include "compositor.h"
 
 static void destroy_surface_listener(struct wl_listener *listener, void *data) {
-	struct wlr_surface *surface = wl_resource_get_user_data(data);
-	struct wl_compositor_state *state = surface->compositor_data;
-	assert(data == surface->resource);
-
-	struct wl_resource *res = NULL;
-	wl_list_for_each(res, &state->surfaces, link) {
-		if (res == surface->resource) {
-			wl_list_remove(wl_resource_get_link(res));
-			break;
-		}
-	}
+	wl_list_remove(wl_resource_get_link(data));
 }
 
 static void wl_compositor_create_surface(struct wl_client *client,

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -11,7 +11,6 @@ executable('tablet', 'tablet.c', dependencies: wlroots, link_with: lib_shared)
 compositor_src = [
   'compositor/main.c',
   'compositor/wl_compositor.c',
-  'compositor/wl_shell.c',
 ]
 
 executable('compositor', compositor_src,

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -1,0 +1,23 @@
+#ifndef _WLR_WL_SHELL_H
+#define _WLR_WL_SHELL_H
+#include <wayland-server.h>
+
+struct wlr_wl_shell {
+	struct wl_global *wl_global;
+	struct wl_list wl_resources;
+
+	void *data;
+};
+
+struct wlr_wl_shell_surface {
+	struct wlr_texture *wlr_texture;
+
+	void *data;
+};
+
+
+void wlr_wl_shell_init(struct wlr_wl_shell *wlr_wl_shell,
+		struct wl_display *display);
+void wlr_wl_shell_destroy(struct wlr_wl_shell *wlr_wl_shell);
+
+#endif

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -5,12 +5,15 @@
 struct wlr_wl_shell {
 	struct wl_global *wl_global;
 	struct wl_list wl_resources;
+	struct wl_list surfaces;
 
 	void *data;
 };
 
 struct wlr_wl_shell_surface {
+	struct wl_resource *surface;
 	struct wlr_texture *wlr_texture;
+	struct wl_list link;
 
 	void *data;
 };

--- a/include/wlr/types/wlr_wl_shell.h
+++ b/include/wlr/types/wlr_wl_shell.h
@@ -19,8 +19,7 @@ struct wlr_wl_shell_surface {
 };
 
 
-void wlr_wl_shell_init(struct wlr_wl_shell *wlr_wl_shell,
-		struct wl_display *display);
+struct wlr_wl_shell *wlr_wl_shell_create(struct wl_display *display);
 void wlr_wl_shell_destroy(struct wlr_wl_shell *wlr_wl_shell);
 
 #endif

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -18,7 +18,7 @@ struct wlr_xdg_surface_v6 {
 	void *data;
 };
 
-struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_init(struct wl_display *display);
+struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display);
 void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell);
 
 #endif

--- a/types/meson.build
+++ b/types/meson.build
@@ -9,6 +9,7 @@ lib_wlr_types = static_library('wlr_types', files(
     'wlr_tablet_tool.c',
     'wlr_touch.c',
     'wlr_xdg_shell_v6.c',
+    'wlr_wl_shell.c',
   ),
   include_directories: wlr_inc,
   dependencies: [wayland_server, pixman, wlr_protos])

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -98,15 +98,7 @@ static struct wl_shell_interface wl_shell_impl = {
 };
 
 static void wl_shell_destroy(struct wl_resource *resource) {
-	struct wlr_wl_shell *wl_shell = wl_resource_get_user_data(resource);
-	struct wl_resource *_resource = NULL;
-	wl_resource_for_each(_resource, &wl_shell->wl_resources) {
-		if (_resource == resource) {
-			struct wl_list *link = wl_resource_get_link(_resource);
-			wl_list_remove(link);
-			break;
-		}
-	}
+	wl_list_remove(wl_resource_get_link(resource));
 }
 
 static void wl_shell_bind(struct wl_client *wl_client, void *_wl_shell,

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -145,6 +145,7 @@ void wlr_wl_shell_destroy(struct wlr_wl_shell *wlr_wl_shell) {
 		wl_list_remove(link);
 	}
 	// TODO: destroy surfaces
-	wl_global_destroy(wlr_wl_shell->wl_global);
+	// TODO: this segfault (wl_display->registry_resource_list is not init)
+	// wl_global_destroy(wlr_wl_shell->wl_global);
 	free(wlr_wl_shell);
 }

--- a/types/wlr_wl_shell.c
+++ b/types/wlr_wl_shell.c
@@ -117,17 +117,22 @@ static void wl_shell_bind(struct wl_client *wl_client, void *_wl_shell,
 	wl_list_insert(&wl_shell->wl_resources, wl_resource_get_link(wl_resource));
 }
 
-void wlr_wl_shell_init(struct wlr_wl_shell *wlr_wl_shell,
-		struct wl_display *display) {
+struct wlr_wl_shell *wlr_wl_shell_create(struct wl_display *display) {
+	struct wlr_wl_shell *wlr_wl_shell =
+		calloc(1, sizeof(struct wlr_wl_shell));
+	if (!wlr_wl_shell) {
+		return NULL;
+	}
 	struct wl_global *wl_global = wl_global_create(display,
 		&wl_shell_interface, 1, wlr_wl_shell, wl_shell_bind);
 	if (!wl_global) {
-		// TODO: return failure somehow
-		return;
+		free(wlr_wl_shell);
+		return NULL;
 	}
 	wlr_wl_shell->wl_global = wl_global;
 	wl_list_init(&wlr_wl_shell->wl_resources);
 	wl_list_init(&wlr_wl_shell->surfaces);
+	return wlr_wl_shell;
 }
 
 void wlr_wl_shell_destroy(struct wlr_wl_shell *wlr_wl_shell) {
@@ -141,4 +146,5 @@ void wlr_wl_shell_destroy(struct wlr_wl_shell *wlr_wl_shell) {
 	}
 	// TODO: destroy surfaces
 	wl_global_destroy(wlr_wl_shell->wl_global);
+	free(wlr_wl_shell);
 }

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -179,7 +179,7 @@ static void xdg_shell_bind(struct wl_client *wl_client, void *_xdg_shell,
 	wl_list_insert(&xdg_shell->wl_resources, wl_resource_get_link(wl_resource));
 }
 
-struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_init(struct wl_display *display) {
+struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display) {
 	struct wlr_xdg_shell_v6 *xdg_shell =
 		calloc(1, sizeof(struct wlr_xdg_shell_v6));
 	if (!xdg_shell) {
@@ -188,7 +188,7 @@ struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_init(struct wl_display *display) {
 	struct wl_global *wl_global = wl_global_create(display,
 		&zxdg_shell_v6_interface, 1, xdg_shell, xdg_shell_bind);
 	if (!wl_global) {
-		wlr_xdg_shell_v6_destroy(xdg_shell);
+		free(xdg_shell);
 		return NULL;
 	}
 	xdg_shell->wl_global = wl_global;

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -93,6 +93,7 @@ static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation =
 
 static void xdg_surface_destroy(struct wl_resource *resource) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	wl_list_remove(&surface->link);
 	free(surface);
 }
 

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -158,11 +158,14 @@ static void xdg_shell_pong(struct wl_client *client,
 }
 
 static struct zxdg_shell_v6_interface xdg_shell_impl = {
-	.destroy = resource_destroy,
 	.create_positioner = xdg_shell_create_positioner,
 	.get_xdg_surface = xdg_shell_get_xdg_surface,
 	.pong = xdg_shell_pong,
 };
+
+static void xdg_shell_destroy(struct wl_resource *resource) {
+	wl_list_remove(wl_resource_get_link(resource));
+}
 
 static void xdg_shell_bind(struct wl_client *wl_client, void *_xdg_shell,
 		uint32_t version, uint32_t id) {
@@ -175,7 +178,7 @@ static void xdg_shell_bind(struct wl_client *wl_client, void *_xdg_shell,
 	}
 	struct wl_resource *wl_resource = wl_resource_create(
 		wl_client, &zxdg_shell_v6_interface, version, id);
-	wl_resource_set_implementation(wl_resource, &xdg_shell_impl, xdg_shell, NULL);
+	wl_resource_set_implementation(wl_resource, &xdg_shell_impl, xdg_shell, xdg_shell_destroy);
 	wl_list_insert(&xdg_shell->wl_resources, wl_resource_get_link(wl_resource));
 }
 
@@ -207,6 +210,7 @@ void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell) {
 		wl_list_remove(link);
 	}
 	// TODO: destroy surfaces
-	wl_global_destroy(xdg_shell->wl_global);
+	// TODO: this segfault (wl_display->registry_resource_list is not init)
+	// wl_global_destroy(xdg_shell->wl_global);
 	free(xdg_shell);
 }


### PR DESCRIPTION
This is just a trivial move that "works" e.g. mpv will create a wl_shell surface and play in it.

BUT there is a lot wrong with the code as it was. I'm getting segfaults when destroying xdg_shell, segfaults when destroying wl_shells, segfaults accessing freed elements in examples/compositor/wl_compositor.c.... (these aren't new, I'm getting them with the old code, but I can't test what I'm doing and I don't like it)

I have more commits that fix part of them, but I need more time to understand what makes xdg_shell xdg_shell and what makes wl_shell wl_shell and what I'm free to modify (e.g. changing how we store a list of surfaces for example)
Unless we really can't move forward without this I'd rather just have another day or so to finish that