### PR TITLE
Prevent alloc errors from crashing in `list_t`

### DIFF
--- a/backend/libinput/events.c
+++ b/backend/libinput/events.c
@@ -44,11 +44,14 @@ static struct wlr_input_device *allocate_device(
 		return NULL;
 	}
 	struct wlr_input_device *wlr_dev = &wlr_libinput_dev->wlr_input_device;
+	if (list_add(wlr_devices, wlr_dev) == -1) {
+		free(wlr_libinput_dev);
+		return NULL;
+	}
 	wlr_libinput_dev->handle = libinput_dev;
 	libinput_device_ref(libinput_dev);
 	wlr_input_device_init(wlr_dev, type, &input_device_impl,
 			name, vendor, product);
-	list_add(wlr_devices, wlr_dev);
 	return wlr_dev;
 }
 

--- a/backend/multi/backend.c
+++ b/backend/multi/backend.c
@@ -120,6 +120,12 @@ void wlr_multi_backend_add(struct wlr_backend *_multi,
 		wlr_log(L_ERROR, "Could not add backend: allocation failed");
 		return;
 	}
+	if (list_add(multi->backends, sub) == -1) {
+		wlr_log(L_ERROR, "Could not add backend: allocation failed");
+		free(sub);
+		return;
+	}
+
 	sub->backend = backend;
 	sub->container = &multi->backend;
 
@@ -137,8 +143,6 @@ void wlr_multi_backend_add(struct wlr_backend *_multi,
 	wl_signal_add(&backend->events.input_remove, &sub->input_remove);
 	wl_signal_add(&backend->events.output_add, &sub->output_add);
 	wl_signal_add(&backend->events.output_remove, &sub->output_remove);
-
-	list_add(multi->backends, sub);
 }
 
 struct wlr_session *wlr_multi_get_session(struct wlr_backend *_backend) {

--- a/backend/wayland/wl_seat.c
+++ b/backend/wayland/wl_seat.c
@@ -188,7 +188,7 @@ static struct wlr_input_device *allocate_device(struct wlr_wl_backend *backend,
 		enum wlr_input_device_type type) {
 	struct wlr_wl_input_device *wlr_wl_dev;
 	if (!(wlr_wl_dev = calloc(1, sizeof(struct wlr_wl_input_device)))) {
-		wlr_log(L_ERROR, "Allocation failed: %s", strerror(errno));
+		wlr_log_errno(L_ERROR, "Allocation failed");
 		return NULL;
 	}
 
@@ -200,7 +200,11 @@ static struct wlr_input_device *allocate_device(struct wlr_wl_backend *backend,
 	struct wlr_input_device *wlr_device = &wlr_wl_dev->wlr_input_device;
 	wlr_input_device_init(wlr_device, type, &input_device_impl,
 			name, vendor, product);
-	list_add(backend->devices, wlr_device);
+	if (list_add(backend->devices, wlr_device) == -1) {
+		wlr_log_errno(L_ERROR, "Allocation failed");
+		free(wlr_wl_dev);
+		return NULL;
+	}
 	return wlr_device;
 }
 

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -65,7 +65,9 @@ static void handle_touch_down(struct touch_state *tstate, int32_t slot,
 	point->slot = slot;
 	point->x = x / width;
 	point->y = y / height;
-	list_add(sample->touch_points, point);
+	if (list_add(sample->touch_points, point) == -1) {
+		free(point);
+	}
 }
 
 static void handle_touch_up(struct touch_state *tstate, int32_t slot) {

--- a/include/wlr/util/list.h
+++ b/include/wlr/util/list.h
@@ -9,16 +9,45 @@ typedef struct {
 	void **items;
 } list_t;
 
+/**
+ * Creates a new list, may return `NULL` on failure
+ */
 list_t *list_create(void);
 void list_free(list_t *list);
 void list_foreach(list_t *list, void (*callback)(void *item));
-void list_add(list_t *list, void *item);
-void list_push(list_t *list, void *item);
-void list_insert(list_t *list, size_t index, void *item);
+/**
+ * Add `item` to the end of a list.
+ * Returns: new list length or `-1` on failure
+ */
+int list_add(list_t *list, void *item);
+/**
+ * Add `item` to the end of a list.
+ * Returns: new list length or `-1` on failure
+ */
+int list_push(list_t *list, void *item);
+/**
+ * Place `item` into index `index` in the list
+ * Returns: new list length or `-1` on failure
+ */
+int list_insert(list_t *list, size_t index, void *item);
+/**
+ * Remove an item from the list
+ */
 void list_del(list_t *list, size_t index);
+/**
+ * Remove and return an item from the end of the list
+ */
 void *list_pop(list_t *list);
+/**
+ * Get a reference to the last item of a list without removal
+ */
 void *list_peek(list_t *list);
-void list_cat(list_t *list, list_t *source);
+/**
+ * Append each item in `source` to `list`
+ * Does not modify `source`
+ * Returns: new list length or `-1` on failure
+ */
+int list_cat(list_t *list, list_t *source);
 // See qsort. Remember to use *_qsort functions as compare functions,
 // because they dereference the left and right arguments first!
 void list_qsort(list_t *list, int compare(const void *left, const void *right));


### PR DESCRIPTION
This commit changes the `list_t` api so that alloc errors can be
detected and worked around. Also fixes errors not found in 5cc7342