### PR TITLE
Fix surface buffer uploading

### DIFF
--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -38,6 +38,7 @@ struct wlr_surface {
 
 	float buffer_to_surface_matrix[16];
 	float surface_to_buffer_matrix[16];
+	bool reupload_buffer;
 
 	struct {
 		struct wl_signal commit;


### PR DESCRIPTION
The patch from #100.
I only tested this with the wayland backend (where it works now), gnome-calculator seems to still
crash on the drm backend i noticed (due to something else though).
There is no gl error anymore.
I would be still ok with not merging this yet, maybe someone else comes up with something better (or finds the new reason for the crash).