### PR TITLE
output: default scale to 1

### DIFF
--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -97,6 +97,7 @@ void wlr_output_init(struct wlr_output *output,
 	output->impl = impl;
 	output->modes = list_create();
 	output->transform = WL_OUTPUT_TRANSFORM_NORMAL;
+	output->scale = 1;
 	wl_signal_init(&output->events.frame);
 	wl_signal_init(&output->events.resolution);
 }


### PR DESCRIPTION
This prevents us from telling application our scale is 0, when it has no
reason to be.