### PR TITLE
Fix wild pointer to buffer

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -293,6 +293,7 @@ release:
 	pixman_region32_init(&surface->current.buffer_damage);
 
 	wl_resource_queue_event(surface->current.buffer, WL_BUFFER_RELEASE);
+	surface->current.buffer = NULL;
 }
 
 static void surface_set_buffer_transform(struct wl_client *client,


### PR DESCRIPTION
After the buffer is released from the release event, it should no longer be
accessed.

Fixes a GTK crash.