### PR TITLE
wlr_surface: use post_event instead of queue

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -292,7 +292,7 @@ release:
 	pixman_region32_fini(&surface->current.buffer_damage);
 	pixman_region32_init(&surface->current.buffer_damage);
 
-	wl_resource_queue_event(surface->current.buffer, WL_BUFFER_RELEASE);
+	wl_resource_post_event(surface->current.buffer, WL_BUFFER_RELEASE);
 	surface->current.buffer = NULL;
 }
 


### PR DESCRIPTION
This fixes not sending anything back to the client if the only event
it's waiting for is a buffer release, and nothing else is in the pipe.

Workaround for #102 - there probably is a better solution as weston and
wlc do not need to use post_event here.