### PR TITLE
Cleanups

### DIFF
--- a/backend/drm/drm.c
+++ b/backend/drm/drm.c
@@ -598,12 +598,12 @@ static bool wlr_drm_output_set_cursor(struct wlr_output *_output,
 		wlr_matrix_texture(plane->matrix, plane->width, plane->height,
 			output->output.transform ^ WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
-		plane->wlr_rend = wlr_gles2_renderer_init(&backend->backend);
+		plane->wlr_rend = wlr_gles2_renderer_create(&backend->backend);
 		if (!plane->wlr_rend) {
 			return false;
 		}
 
-		plane->wlr_tex = wlr_render_texture_init(plane->wlr_rend);
+		plane->wlr_tex = wlr_render_texture_create(plane->wlr_rend);
 		if (!plane->wlr_tex) {
 			return false;
 		}

--- a/backend/libinput/backend.c
+++ b/backend/libinput/backend.c
@@ -109,6 +109,7 @@ static void wlr_libinput_backend_destroy(struct wlr_backend *_backend) {
 		list_free(wlr_devices);
 	}
 	list_free(backend->wlr_device_lists);
+	wl_event_source_remove(backend->input_event);
 	libinput_unref(backend->libinput_context);
 	free(backend);
 }

--- a/backend/wayland/backend.c
+++ b/backend/wayland/backend.c
@@ -88,6 +88,7 @@ static void wlr_wl_backend_destroy(struct wlr_backend *_backend) {
 	list_free(backend->outputs);
 	free(backend->seat_name);
 
+	wl_event_source_remove(backend->remote_display_src);
 	wlr_egl_free(&backend->egl);
 	if (backend->seat) wl_seat_destroy(backend->seat);
 	if (backend->shm) wl_shm_destroy(backend->shm);

--- a/backend/wayland/output.c
+++ b/backend/wayland/output.c
@@ -224,7 +224,6 @@ struct wlr_output *wlr_wl_output_create(struct wlr_backend *_backend) {
 
 	wlr_output->width = 640;
 	wlr_output->height = 480;
-	wlr_output->scale = 1;
 	strncpy(wlr_output->make, "wayland", sizeof(wlr_output->make));
 	strncpy(wlr_output->model, "wayland", sizeof(wlr_output->model));
 	snprintf(wlr_output->name, sizeof(wlr_output->name), "WL-%zd",

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -147,7 +147,7 @@ int main() {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(compositor.backend);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/compositor/main.c
+++ b/examples/compositor/main.c
@@ -178,9 +178,13 @@ int main() {
 		break;
 	}
 
-	compositor_run(&compositor);
+	wl_display_run(compositor.display);
 
-	wlr_wl_shell_destroy(state.wl_shell);
-	wlr_xdg_shell_v6_destroy(state.xdg_shell);
 	close(state.keymap_fd);
+	wlr_seat_destroy(state.wl_seat);
+	wlr_data_device_manager_destroy(state.data_device_manager);
+	wlr_xdg_shell_v6_destroy(state.xdg_shell);
+	wlr_wl_shell_destroy(state.wl_shell);
+	wlr_renderer_destroy(state.renderer);
+	compositor_fini(&compositor);
 }

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -198,10 +198,11 @@ int main(int argc, char *argv[]) {
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ABGR8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);
 
-	compositor_run(&compositor);
+	wl_display_run(compositor.display);
 
 	wlr_texture_destroy(state.cat_texture);
 	wlr_renderer_destroy(state.renderer);
+	compositor_fini(&compositor);
 
 	wlr_output_layout_destroy(state.layout);
 

--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -193,8 +193,8 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend);
-	state.cat_texture = wlr_render_texture_init(state.renderer);
+	state.renderer = wlr_gles2_renderer_create(compositor.backend);
+	state.cat_texture = wlr_render_texture_create(state.renderer);
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ABGR8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);
 

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -146,7 +146,8 @@ int main(int argc, char *argv[]) {
 	}
 
 	compositor_init(&compositor);
-	compositor_run(&compositor);
+	wl_display_run(compositor.display);
+	compositor_fini(&compositor);
 
 	wlr_xcursor_theme_destroy(theme);
 }

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -145,10 +145,11 @@ int main(int argc, char *argv[]) {
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ABGR8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);
 
-	compositor_run(&compositor);
+	wl_display_run(compositor.display);
 
 	wlr_texture_destroy(state.cat_texture);
 	wlr_renderer_destroy(state.renderer);
+	compositor_fini(&compositor);
 
 	example_config_destroy(state.config);
 }

--- a/examples/rotation.c
+++ b/examples/rotation.c
@@ -132,12 +132,12 @@ int main(int argc, char *argv[]) {
 	compositor.keyboard_key_cb = handle_keyboard_key;
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(compositor.backend);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);
 	}
-	state.cat_texture = wlr_render_texture_init(state.renderer);
+	state.cat_texture = wlr_render_texture_create(state.renderer);
 	if (!state.cat_texture) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/shared.c
+++ b/examples/shared.c
@@ -674,8 +674,7 @@ void compositor_init(struct compositor_state *state) {
 	}
 }
 
-void compositor_run(struct compositor_state *state) {
-	wl_display_run(state->display);
+void compositor_fini(struct compositor_state *state) {
 	wlr_backend_destroy(state->backend);
 	wl_display_destroy(state->display);
 }

--- a/examples/shared.h
+++ b/examples/shared.h
@@ -151,6 +151,6 @@ struct compositor_state {
 };
 
 void compositor_init(struct compositor_state *state);
-void compositor_run(struct compositor_state *state);
+void compositor_fini(struct compositor_state *state);
 
 #endif

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -52,5 +52,6 @@ int main() {
 		.output_frame_cb = handle_output_frame,
 	};
 	compositor_init(&compositor);
-	compositor_run(&compositor);
+	wl_display_run(compositor.display);
+	compositor_fini(&compositor);
 }

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -153,7 +153,7 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(compositor.backend);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/tablet.c
+++ b/examples/tablet.c
@@ -158,7 +158,8 @@ int main(int argc, char *argv[]) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);
 	}
-	compositor_run(&compositor);
+	wl_display_run(compositor.display);
 
 	wlr_renderer_destroy(state.renderer);
+	compositor_fini(&compositor);
 }

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -107,12 +107,12 @@ int main(int argc, char *argv[]) {
 	};
 	compositor_init(&compositor);
 
-	state.renderer = wlr_gles2_renderer_init(compositor.backend);
+	state.renderer = wlr_gles2_renderer_create(compositor.backend);
 	if (!state.renderer) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);
 	}
-	state.cat_texture = wlr_render_texture_init(state.renderer);
+	state.cat_texture = wlr_render_texture_create(state.renderer);
 	if (!state.cat_texture) {
 		wlr_log(L_ERROR, "Could not start compositor, OOM");
 		exit(EXIT_FAILURE);

--- a/examples/touch.c
+++ b/examples/touch.c
@@ -120,8 +120,9 @@ int main(int argc, char *argv[]) {
 	wlr_texture_upload_pixels(state.cat_texture, WL_SHM_FORMAT_ARGB8888,
 		cat_tex.width, cat_tex.width, cat_tex.height, cat_tex.pixel_data);
 
-	compositor_run(&compositor);
+	wl_display_run(compositor.display);
 
 	wlr_texture_destroy(state.cat_texture);
 	wlr_renderer_destroy(state.renderer);
+	compositor_fini(&compositor);
 }

--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -49,7 +49,7 @@ extern struct shaders shaders;
 
 const struct pixel_format *gl_format_for_wl_format(enum wl_shm_format fmt);
 
-struct wlr_texture *gles2_texture_init();
+struct wlr_texture *gles2_texture_create();
 
 extern const GLchar quad_vertex_src[];
 extern const GLchar quad_fragment_src[];

--- a/include/wlr/render.h
+++ b/include/wlr/render.h
@@ -12,7 +12,7 @@ void wlr_renderer_end(struct wlr_renderer *r);
 /**
  * Requests a texture handle from this renderer.
  */
-struct wlr_texture *wlr_render_texture_init(struct wlr_renderer *r);
+struct wlr_texture *wlr_render_texture_create(struct wlr_renderer *r);
 /**
  * Renders the requested texture using the provided matrix. A typical texture
  * rendering goes like so:

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -4,6 +4,6 @@
 #include <wlr/backend.h>
 
 struct wlr_egl;
-struct wlr_renderer *wlr_gles2_renderer_init(struct wlr_backend *backend);
+struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_backend *backend);
 
 #endif

--- a/include/wlr/render/interface.h
+++ b/include/wlr/render/interface.h
@@ -14,7 +14,7 @@ struct wlr_renderer {
 struct wlr_renderer_impl {
 	void (*begin)(struct wlr_renderer *renderer, struct wlr_output *output);
 	void (*end)(struct wlr_renderer *renderer);
-	struct wlr_texture *(*texture_init)(struct wlr_renderer *renderer);
+	struct wlr_texture *(*texture_create)(struct wlr_renderer *renderer);
 	bool (*render_with_matrix)(struct wlr_renderer *renderer,
 		struct wlr_texture *texture, const float (*matrix)[16]);
 	void (*render_quad)(struct wlr_renderer *renderer,

--- a/render/gles2/renderer.c
+++ b/render/gles2/renderer.c
@@ -143,11 +143,11 @@ static void wlr_gles2_end(struct wlr_renderer *renderer) {
 	// no-op
 }
 
-static struct wlr_texture *wlr_gles2_texture_init(
+static struct wlr_texture *wlr_gles2_texture_create(
 		struct wlr_renderer *_renderer) {
 	struct wlr_gles2_renderer *renderer =
 		(struct wlr_gles2_renderer *)_renderer;
-	return gles2_texture_init(renderer->egl);
+	return gles2_texture_create(renderer->egl);
 }
 
 static void draw_quad() {
@@ -231,7 +231,7 @@ static bool wlr_gles2_buffer_is_drm(struct wlr_renderer *_renderer,
 static struct wlr_renderer_impl wlr_renderer_impl = {
 	.begin = wlr_gles2_begin,
 	.end = wlr_gles2_end,
-	.texture_init = wlr_gles2_texture_init,
+	.texture_create = wlr_gles2_texture_create,
 	.render_with_matrix = wlr_gles2_render_texture,
 	.render_quad = wlr_gles2_render_quad,
 	.render_ellipse = wlr_gles2_render_ellipse,
@@ -239,7 +239,7 @@ static struct wlr_renderer_impl wlr_renderer_impl = {
 	.buffer_is_drm = wlr_gles2_buffer_is_drm,
 };
 
-struct wlr_renderer *wlr_gles2_renderer_init(struct wlr_backend *backend) {
+struct wlr_renderer *wlr_gles2_renderer_create(struct wlr_backend *backend) {
 	init_globals();
 	struct wlr_gles2_renderer *renderer;
 	if (!(renderer = calloc(1, sizeof(struct wlr_gles2_renderer)))) {

--- a/render/gles2/texture.c
+++ b/render/gles2/texture.c
@@ -276,7 +276,7 @@ static struct wlr_texture_impl wlr_texture_impl = {
 	.destroy = gles2_texture_destroy,
 };
 
-struct wlr_texture *gles2_texture_init(struct wlr_egl *egl) {
+struct wlr_texture *gles2_texture_create(struct wlr_egl *egl) {
 	struct wlr_gles2_texture *texture;
 	if (!(texture = calloc(1, sizeof(struct wlr_gles2_texture)))) {
 		return NULL;

--- a/render/wlr_renderer.c
+++ b/render/wlr_renderer.c
@@ -23,8 +23,8 @@ void wlr_renderer_end(struct wlr_renderer *r) {
 	r->impl->end(r);
 }
 
-struct wlr_texture *wlr_render_texture_init(struct wlr_renderer *r) {
-	return r->impl->texture_init(r);
+struct wlr_texture *wlr_render_texture_create(struct wlr_renderer *r) {
+	return r->impl->texture_create(r);
 }
 
 bool wlr_render_with_matrix(struct wlr_renderer *r,

--- a/types/wlr_output.c
+++ b/types/wlr_output.c
@@ -139,14 +139,14 @@ bool wlr_output_set_cursor(struct wlr_output *output,
 
 	if (!output->cursor.renderer) {
 		/* NULL egl is okay given that we are only using pixel buffers */
-		output->cursor.renderer = wlr_gles2_renderer_init(NULL);
+		output->cursor.renderer = wlr_gles2_renderer_create(NULL);
 		if (!output->cursor.renderer) {
 			return false;
 		}
 	}
 
 	if (!output->cursor.texture) {
-		output->cursor.texture = wlr_render_texture_init(output->cursor.renderer);
+		output->cursor.texture = wlr_render_texture_create(output->cursor.renderer);
 		if (!output->cursor.texture) {
 			return false;
 		}

--- a/types/wlr_region.c
+++ b/types/wlr_region.c
@@ -26,9 +26,9 @@ static void region_destroy(struct wl_client *client, struct wl_resource *resourc
 }
 
 static const struct wl_region_interface region_interface = {
-	region_destroy,
-	region_add,
-	region_subtract,
+	.destroy = region_destroy,
+	.add = region_add,
+	.subtract = region_subtract,
 };
 
 static void destroy_region(struct wl_resource *resource) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -204,20 +204,20 @@ static void wlr_surface_to_buffer_region(struct wlr_surface *surface,
 static void surface_commit(struct wl_client *client,
 		struct wl_resource *resource) {
 	struct wlr_surface *surface = wl_resource_get_user_data(resource);
-	int update_size = 0;
-	int update_damage = 0;
+	bool update_size = false;
+	bool update_damage = false;
 
 	if ((surface->pending.invalid & WLR_SURFACE_INVALID_SCALE)) {
 		surface->current.scale = surface->pending.scale;
-		update_size = 1;
+		update_size = true;
 	}
 	if ((surface->pending.invalid & WLR_SURFACE_INVALID_TRANSFORM)) {
 		surface->current.transform = surface->pending.transform;
-		update_size = 1;
+		update_size = true;
 	}
 	if ((surface->pending.invalid & WLR_SURFACE_INVALID_BUFFER)) {
 		surface->current.buffer = surface->pending.buffer;
-		update_size = 1;
+		update_size = true;
 	}
 	if (update_size) {
 		int32_t oldw = surface->current.buffer_width;
@@ -236,7 +236,7 @@ static void surface_commit(struct wl_client *client,
 			surface->current.height);
 
 		pixman_region32_clear(&surface->pending.surface_damage);
-		update_damage = 1;
+		update_damage = true;
 	}
 	if ((surface->pending.invalid & WLR_SURFACE_INVALID_BUFFER_DAMAGE)) {
 		pixman_region32_union(&surface->current.buffer_damage,
@@ -244,7 +244,7 @@ static void surface_commit(struct wl_client *client,
 			&surface->pending.buffer_damage);
 
 		pixman_region32_clear(&surface->pending.buffer_damage);
-		update_damage = 1;
+		update_damage = true;
 	}
 	if (update_damage) {
 		pixman_region32_t buffer_damage;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -356,7 +356,7 @@ struct wlr_surface *wlr_surface_create(struct wl_resource *res,
 		return NULL;
 	}
 	surface->renderer = renderer;
-	surface->texture = wlr_render_texture_init(renderer);
+	surface->texture = wlr_render_texture_create(renderer);
 	surface->resource = res;
 	surface->current.scale = 1;
 	surface->pending.scale = 1;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -326,16 +326,16 @@ static void surface_damage_buffer(struct wl_client *client,
 }
 
 const struct wl_surface_interface surface_interface = {
-	surface_destroy,
-	surface_attach,
-	surface_damage,
-	surface_frame,
-	surface_set_opaque_region,
-	surface_set_input_region,
-	surface_commit,
-	surface_set_buffer_transform,
-	surface_set_buffer_scale,
-	surface_damage_buffer
+	.destroy = surface_destroy,
+	.attach = surface_attach,
+	.damage = surface_damage,
+	.frame = surface_frame,
+	.set_opaque_region = surface_set_opaque_region,
+	.set_input_region = surface_set_input_region,
+	.commit = surface_commit,
+	.set_buffer_transform = surface_set_buffer_transform,
+	.set_buffer_scale = surface_set_buffer_scale,
+	.damage_buffer = surface_damage_buffer
 };
 
 static void destroy_surface(struct wl_resource *resource) {

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -230,6 +230,7 @@ static void surface_commit(struct wl_client *client,
 			&buffer_damage, surface->current.width, surface->current.height);
 		pixman_region32_union(&surface->current.buffer_damage,
 			&surface->current.buffer_damage, &buffer_damage);
+		pixman_region32_fini(&buffer_damage);
 
 		pixman_region32_intersect_rect(&surface->current.buffer_damage,
 			&surface->current.buffer_damage, 0, 0,
@@ -237,6 +238,7 @@ static void surface_commit(struct wl_client *client,
 
 		pixman_region32_clear(&surface->pending.surface_damage);
 		pixman_region32_clear(&surface->pending.buffer_damage);
+		pixman_region32_clear(&surface->pending.opaque);
 	}
 	// TODO: Commit other changes
 


### PR DESCRIPTION
Lots of small cleanups:
 - rename init to create for some init functions that did allocs for us
 - more memory leaks, mainly examples/compositor not calling destroy functions.
 - the biggest part is probably wlr_surface, I've taken the liberty to reorder things a bit. There should not be any functional change (except that we no longer union with an empty buffer needlessly), but can be worth looking at.