### PR TITLE
Change meson to be more configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,15 +1,16 @@
 project('wlroots', 'c',
   license: 'MIT',
-  default_options: 'c_std=c11')
+  default_options: [
+    'c_std=c11',
+    'warning_level=2',
+    'werror=true',
+  ])
 
-add_project_arguments('-Wall', '-Wextra', '-Wno-unused-parameter', '-Werror', language: 'c')
+add_project_arguments('-Wno-unused-parameter', language: 'c')
 add_project_arguments('-DWLR_SRC_DIR="@0@"'.format(meson.source_root()), language: 'c')
 add_project_link_arguments('-Wl,-rpath,@0@'.format(meson.build_root()), language: 'c')
 
 wlr_inc = include_directories('include')
-
-#add_project_arguments('-flto', language: 'c')
-#add_project_link_arguments('-flto', language: 'c')
 
 cc = meson.get_compiler('c')
 
@@ -21,25 +22,25 @@ endif
 
 wayland_server = dependency('wayland-server')
 wayland_client = dependency('wayland-client')
-wayland_egl  = dependency('wayland-egl')
+wayland_egl    = dependency('wayland-egl')
 wayland_protos = dependency('wayland-protocols')
-egl      = dependency('egl')
-glesv2     = dependency('glesv2')
-drm      = dependency('libdrm')
-gbm      = dependency('gbm')
-libinput     = dependency('libinput')
-xkbcommon    = dependency('xkbcommon')
-udev       = dependency('libudev')
-pixman     = dependency('pixman-1')
-libcap     = dependency('libcap', required: false)
-systemd    = dependency('libsystemd', required: false)
-math       = cc.find_library('m', required: false)
+egl            = dependency('egl')
+glesv2         = dependency('glesv2')
+drm            = dependency('libdrm')
+gbm            = dependency('gbm')
+libinput       = dependency('libinput')
+xkbcommon      = dependency('xkbcommon')
+udev           = dependency('libudev')
+pixman         = dependency('pixman-1')
+libcap         = dependency('libcap', required: false)
+systemd        = dependency('libsystemd', required: false)
+math           = cc.find_library('m', required: false)
 
-if libcap.found()
+if libcap.found() and get_option('enable_libcap')
   add_project_arguments('-DHAS_LIBCAP', language: 'c')
 endif
 
-if systemd.found()
+if systemd.found() and get_option('enable_systemd')
   add_project_arguments('-DHAS_SYSTEMD', language: 'c')
 endif
 
@@ -50,7 +51,7 @@ subdir('types')
 subdir('util')
 subdir('xcursor')
 
-_wlr_deps = [
+wlr_deps = [
   wayland_server,
   wayland_client,
   wayland_egl,
@@ -77,11 +78,11 @@ lib_wlr = library('wlroots', files('dummy.c'),
     lib_wlr_util,
     lib_wlr_xcursor,
   ],
-  dependencies: _wlr_deps,
+  dependencies: wlr_deps,
   include_directories: wlr_inc)
 
 wlroots = declare_dependency(link_with: lib_wlr,
-  dependencies: _wlr_deps,
+  dependencies: wlr_deps,
   include_directories: wlr_inc)
 
 subdir('examples')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('enable_libcap', type: 'boolean', value: true, description: 'Enable support for capabilities')
+option('enable_systemd', type: 'boolean', value: true, description: 'Enable support for logind')


### PR DESCRIPTION
We move the warning options into the project's default_options, meaning
a user can configure them with `meson configure` and not need to edit
the file.

We also make it possible to disable logind/libcap even if they're
present.