### PR TITLE
example compositor: handle keyboard after we're done with init

### DIFF
--- a/examples/compositor.c
+++ b/examples/compositor.c
@@ -143,7 +143,6 @@ int main() {
 	struct compositor_state compositor = { 0,
 		.data = &state,
 		.output_frame_cb = handle_output_frame,
-		.keyboard_key_cb = handle_keyboard_key
 	};
 	compositor_init(&compositor);
 
@@ -177,6 +176,8 @@ int main() {
 		free(keymap);
 		break;
 	}
+
+	compositor.keyboard_key_cb = handle_keyboard_key;
 
 	wl_display_run(compositor.display);
 


### PR DESCRIPTION
the libinput backend does wl_display roundtrips, during which there is a
small window where keystrokes can be handled before the rest of the example
compositor is ready.
Setting the callback later ensures we're not called at this point