### PR TITLE
Xwayland double fork & leak fix

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -1,7 +1,6 @@
 #ifndef _WLR_XWAYLAND_H
 #define _WLR_XWAYLAND_H
 #include <time.h>
-#include <sys/types.h>
 #include <stdbool.h>
 #include <wlr/types/wlr_compositor.h>
 #include <xcb/xcb.h>

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -211,6 +211,7 @@ static int x11_event_handler(int fd, uint32_t mask, void *data) {
 				event->response_type & XCB_EVENT_RESPONSE_TYPE_MASK);
 			break;
 		}
+		free(event);
 	}
 
 	xcb_flush(xwm->xcb_conn);


### PR DESCRIPTION
Double-forking xwayland was a bit more complicated than I had hoped (because the SIGUSR1 signal when xserver is ready only goes to parent), but I guess it's not too bad.

Also used the opportunity to move some code around and only try to init xwm if the Xwayland process started properly, that wasn't checked correctly before.