### PR TITLE
wlr_cursor: automatically handle layout changes

### DIFF
--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -151,15 +151,15 @@ static void handle_output_add(struct output_state *ostate) {
 
 	configure_devices(sample);
 
-	// TODO move to wlr_cursor
+	// TODO the cursor must be set depending on which surface it is displayed
+	// over which should happen in the compositor.
 	if (!wlr_output_set_cursor(wlr_output, image->buffer,
 			image->width, image->width, image->height)) {
 		wlr_log(L_DEBUG, "Failed to set hardware cursor");
 		return;
 	}
-	if (!wlr_output_move_cursor(wlr_output, 0, 0)) {
-		wlr_log(L_DEBUG, "Failed to move hardware cursor");
-	}
+
+	wlr_cursor_warp(sample->cursor, NULL, sample->cursor->x, sample->cursor->y);
 }
 
 static void handle_output_remove(struct output_state *ostate) {

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -9,6 +9,11 @@ struct wlr_output_layout_state;
 struct wlr_output_layout {
 	struct wl_list outputs;
 	struct wlr_output_layout_state *state;
+
+	struct {
+		struct wl_signal change;
+		struct wl_signal destroy;
+	} events;
 };
 
 struct wlr_output_layout_output_state;


### PR DESCRIPTION
Automatically set the cursor on outputs when a layout is attached.

Add a `destroy` event to wlr_output_layout and listen for it in wlr_cursor to
detach the output layout cleanly.

Add a `change` event to wlr_output_layout and listen for it in wlr_cursor to
set the cursor on the outputs in the layout.

Reconfigure the cursor on the outputs when the xcursor changes.