### PR TITLE
pointer.c: refactor device configuration

### DIFF
--- a/examples/config.c
+++ b/examples/config.c
@@ -278,3 +278,70 @@ struct device_config *example_config_get_device(struct example_config *config,
 
 	return NULL;
 }
+
+/**
+ * Set device output mappings to NULL and configure region mappings.
+ */
+static void reset_device_mappings(struct example_config *config,
+		struct wlr_cursor *cursor, struct wlr_input_device *device) {
+	struct device_config *d_config;
+	wlr_cursor_map_input_to_output(cursor, device, NULL);
+	d_config = example_config_get_device(config, device);
+	if (d_config) {
+		wlr_cursor_map_input_to_region(cursor, device,
+			d_config->mapped_box);
+	}
+}
+
+static void set_device_output_mappings(struct example_config *config,
+		struct wlr_cursor *cursor, struct wlr_output *output,
+		struct wlr_input_device *device) {
+	struct device_config *d_config;
+	d_config = example_config_get_device(config, device);
+	if (d_config &&
+			d_config->mapped_output &&
+			strcmp(d_config->mapped_output, output->name) == 0) {
+		wlr_cursor_map_input_to_output(cursor, device, output);
+	}
+}
+
+void example_config_configure_cursor(struct example_config *config,
+		struct wlr_cursor *cursor, struct compositor_state *compositor) {
+	struct pointer_state *p_state;
+	struct tablet_tool_state *tt_state;
+	struct touch_state *tch_state;
+	struct output_state *o_state;
+
+	// reset mappings
+	wlr_cursor_map_to_output(cursor, NULL);
+	wl_list_for_each(p_state, &compositor->pointers, link) {
+		reset_device_mappings(config, cursor, p_state->device);
+	}
+	wl_list_for_each(tt_state, &compositor->tablet_tools, link) {
+		reset_device_mappings(config, cursor, tt_state->device);
+	}
+	wl_list_for_each(tch_state, &compositor->touch, link) {
+		reset_device_mappings(config, cursor, tch_state->device);
+	}
+
+	// configure device to output mappings
+	char *mapped_output = config->cursor.mapped_output;
+	wl_list_for_each(o_state, &compositor->outputs, link) {
+		if (mapped_output && strcmp(mapped_output, o_state->output->name) == 0) {
+			wlr_cursor_map_to_output(cursor, o_state->output);
+		}
+
+		wl_list_for_each(p_state, &compositor->pointers, link) {
+			set_device_output_mappings(config, cursor, o_state->output,
+				p_state->device);
+		}
+		wl_list_for_each(tt_state, &compositor->tablet_tools, link) {
+			set_device_output_mappings(config, cursor, o_state->output,
+				tt_state->device);
+		}
+		wl_list_for_each(tch_state, &compositor->touch, link) {
+			set_device_output_mappings(config, cursor, o_state->output,
+				tch_state->device);
+		}
+	}
+}

--- a/examples/config.c
+++ b/examples/config.c
@@ -266,3 +266,15 @@ struct output_config *example_config_get_output(struct example_config *config,
 
 	return NULL;
 }
+
+struct device_config *example_config_get_device(struct example_config *config,
+		struct wlr_input_device *device) {
+	struct device_config *d_config;
+	wl_list_for_each(d_config, &config->devices, link) {
+		if (strcmp(d_config->name, device->name) == 0) {
+			return d_config;
+		}
+	}
+
+	return NULL;
+}

--- a/examples/config.h
+++ b/examples/config.h
@@ -4,6 +4,7 @@
 #define _POSIX_C_SOURCE 200112L
 #endif
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_input_device.h>
 
 struct output_config {
 	char *name;
@@ -40,5 +41,12 @@ void example_config_destroy(struct example_config *config);
  */
 struct output_config *example_config_get_output(struct example_config *config,
 		struct wlr_output *output);
+
+/**
+ * Get configuration for the device. If the device is not configured, returns
+ * NULL.
+ */
+struct device_config *example_config_get_device(struct example_config *config,
+		struct wlr_input_device *device);
 
 #endif

--- a/examples/config.h
+++ b/examples/config.h
@@ -5,6 +5,8 @@
 #endif
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_cursor.h>
+#include "shared.h"
 
 struct output_config {
 	char *name;
@@ -48,5 +50,11 @@ struct output_config *example_config_get_output(struct example_config *config,
  */
 struct device_config *example_config_get_device(struct example_config *config,
 		struct wlr_input_device *device);
+
+/**
+ * Configure cursor device mappings.
+ */
+void example_config_configure_cursor(struct example_config *config,
+		struct wlr_cursor *cursor, struct compositor_state *state);
 
 #endif

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -97,31 +97,29 @@ static void handle_output_frame(struct output_state *output,
 
 static void configure_devices(struct sample_state *sample) {
 	struct sample_input_device *dev;
-	struct device_config *dc;
+	struct device_config *d_config;
 
 	// reset device mappings
 	wl_list_for_each(dev, &sample->devices, link) {
 		wlr_cursor_map_input_to_output(sample->cursor, dev->device, NULL);
-		wl_list_for_each(dc, &sample->config->devices, link) {
-			if (strcmp(dev->device->name, dc->name) == 0) {
-				wlr_cursor_map_input_to_region(sample->cursor, dev->device,
-					dc->mapped_box);
-			}
+		d_config = example_config_get_device(sample->config, dev->device);
+		if (d_config) {
+			wlr_cursor_map_input_to_region(sample->cursor, dev->device,
+				d_config->mapped_box);
 		}
 	}
 
 	struct output_state *ostate;
 	wl_list_for_each(ostate, &sample->compositor->outputs, link) {
-		wl_list_for_each(dc, &sample->config->devices, link) {
+		struct wlr_output *output = ostate->output;
+		wl_list_for_each(dev, &sample->devices, link) {
 			// configure device to output mappings
-			if (dc->mapped_output &&
-					strcmp(dc->mapped_output, ostate->output->name) == 0) {
-				wl_list_for_each(dev, &sample->devices, link) {
-					if (strcmp(dev->device->name, dc->name) == 0) {
-						wlr_cursor_map_input_to_output(sample->cursor,
-							dev->device, ostate->output);
-					}
-				}
+			d_config = example_config_get_device(sample->config, dev->device);
+			if (d_config &&
+					d_config->mapped_output &&
+					strcmp(d_config->mapped_output, output->name) == 0) {
+				wlr_cursor_map_input_to_output(sample->cursor, dev->device,
+					ostate->output);
 			}
 		}
 	}

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -25,11 +25,6 @@
 #include "config.h"
 #include "cat.h"
 
-struct sample_input_device {
-	struct wlr_input_device *device;
-	struct wl_list link;
-};
-
 struct sample_state {
 	struct compositor_state *compositor;
 	struct example_config *config;
@@ -95,36 +90,6 @@ static void handle_output_frame(struct output_state *output,
 	wlr_output_swap_buffers(wlr_output);
 }
 
-static void configure_devices(struct sample_state *sample) {
-	struct sample_input_device *dev;
-	struct device_config *d_config;
-
-	// reset device mappings
-	wl_list_for_each(dev, &sample->devices, link) {
-		wlr_cursor_map_input_to_output(sample->cursor, dev->device, NULL);
-		d_config = example_config_get_device(sample->config, dev->device);
-		if (d_config) {
-			wlr_cursor_map_input_to_region(sample->cursor, dev->device,
-				d_config->mapped_box);
-		}
-	}
-
-	struct output_state *ostate;
-	wl_list_for_each(ostate, &sample->compositor->outputs, link) {
-		struct wlr_output *output = ostate->output;
-		wl_list_for_each(dev, &sample->devices, link) {
-			// configure device to output mappings
-			d_config = example_config_get_device(sample->config, dev->device);
-			if (d_config &&
-					d_config->mapped_output &&
-					strcmp(d_config->mapped_output, output->name) == 0) {
-				wlr_cursor_map_input_to_output(sample->cursor, dev->device,
-					ostate->output);
-			}
-		}
-	}
-}
-
 static void handle_output_add(struct output_state *ostate) {
 	struct sample_state *sample = ostate->compositor->data;
 	struct wlr_output *wlr_output = ostate->output;
@@ -141,13 +106,8 @@ static void handle_output_add(struct output_state *ostate) {
 		wlr_output_layout_add_auto(sample->layout, ostate->output);
 	}
 
-	// cursor configuration
-	char *mapped_output = sample->config->cursor.mapped_output;
-	if (mapped_output && strcmp(mapped_output, wlr_output->name) == 0) {
-		wlr_cursor_map_to_output(sample->cursor, wlr_output);
-	}
-
-	configure_devices(sample);
+	example_config_configure_cursor(sample->config, sample->cursor,
+		sample->compositor);
 
 	// TODO the cursor must be set depending on which surface it is displayed
 	// over which should happen in the compositor.
@@ -165,12 +125,8 @@ static void handle_output_remove(struct output_state *ostate) {
 
 	wlr_output_layout_remove(sample->layout, ostate->output);
 
-	configure_devices(sample);
-
-	char *mapped_output = sample->config->cursor.mapped_output;
-	if (mapped_output && strcmp(mapped_output, ostate->output->name) == 0) {
-		wlr_cursor_map_to_output(sample->cursor, NULL);
-	}
+	example_config_configure_cursor(sample->config, sample->cursor,
+		sample->compositor);
 }
 
 static void handle_input_add(struct compositor_state *state,
@@ -180,25 +136,9 @@ static void handle_input_add(struct compositor_state *state,
 	if (device->type == WLR_INPUT_DEVICE_POINTER ||
 			device->type == WLR_INPUT_DEVICE_TOUCH ||
 			device->type == WLR_INPUT_DEVICE_TABLET_TOOL) {
-		struct sample_input_device *s_device;
-		s_device = calloc(1, sizeof(struct sample_input_device));
-		s_device->device = device;
-
-		wl_list_insert(&sample->devices, &s_device->link);
 		wlr_cursor_attach_input_device(sample->cursor, device);
-		configure_devices(sample);
-	}
-}
-
-static void handle_input_remove(struct compositor_state *state,
-        struct wlr_input_device *device) {
-	struct sample_state *sample = state->data;
-	struct sample_input_device *s_device, *tmp = NULL;
-	wl_list_for_each_safe(s_device, tmp, &sample->devices, link) {
-		if (s_device->device == device) {
-			wl_list_remove(&s_device->link);
-			free(s_device);
-		}
+		example_config_configure_cursor(sample->config, sample->cursor,
+			sample->compositor);
 	}
 }
 
@@ -376,7 +316,6 @@ int main(int argc, char *argv[]) {
 	compositor.output_remove_cb = handle_output_remove;
 	compositor.output_frame_cb = handle_output_frame;
 	compositor.input_add_cb = handle_input_add;
-	compositor.input_remove_cb = handle_input_remove;
 
 	state.compositor = &compositor;
 


### PR DESCRIPTION
It's a bit more readable now, but I'm afraid there's no way we can avoid copy/pasting this into each example that needs a pointer unless they can share `sample_state`.