### PR TITLE
Rename wlr_output_layout_init()

### DIFF
--- a/examples/output-layout.c
+++ b/examples/output-layout.c
@@ -185,7 +185,7 @@ int main(int argc, char *argv[]) {
 
 	state.x_vel = 500;
 	state.y_vel = 500;
-	state.layout = wlr_output_layout_init();
+	state.layout = wlr_output_layout_create();
 	clock_gettime(CLOCK_MONOTONIC, &state.ts_last);
 
 	state.config = parse_args(argc, argv);

--- a/examples/pointer.c
+++ b/examples/pointer.c
@@ -335,7 +335,7 @@ int main(int argc, char *argv[]) {
 
 	state.config = parse_args(argc, argv);
 	state.cursor = wlr_cursor_create();
-	state.layout = wlr_output_layout_init();
+	state.layout = wlr_output_layout_create();
 	wlr_cursor_attach_output_layout(state.cursor, state.layout);
 	wlr_cursor_map_to_region(state.cursor, state.config->cursor.mapped_box);
 	wl_list_init(&state.devices);

--- a/include/wlr/types/wlr_output_layout.h
+++ b/include/wlr/types/wlr_output_layout.h
@@ -25,7 +25,7 @@ struct wlr_output_layout_output {
 	struct wlr_output_layout_output_state *state;
 };
 
-struct wlr_output_layout *wlr_output_layout_init();
+struct wlr_output_layout *wlr_output_layout_create();
 
 void wlr_output_layout_destroy(struct wlr_output_layout *layout);
 

--- a/types/wlr_output_layout.c
+++ b/types/wlr_output_layout.c
@@ -22,7 +22,7 @@ struct wlr_output_layout_output_state {
 	struct wl_listener output_destroy;
 };
 
-struct wlr_output_layout *wlr_output_layout_init() {
+struct wlr_output_layout *wlr_output_layout_create() {
 	struct wlr_output_layout *layout =
 		calloc(1, sizeof(struct wlr_output_layout));
 	layout->state = calloc(1, sizeof(struct wlr_output_layout_state));


### PR DESCRIPTION
Rename wlr_output_layout_init() to wlr_output_layout_create() to be consistent
with the rest of the api.