### PR TITLE
fixes use after free caused by signal lists

### DIFF
--- a/types/wlr_input_device.c
+++ b/types/wlr_input_device.c
@@ -30,7 +30,7 @@ void wlr_input_device_destroy(struct wlr_input_device *dev) {
 	}
 
 	wl_signal_emit(&dev->events.destroy, dev);
-	
+
 	if (dev->_device) {
 		switch (dev->type) {
 		case WLR_INPUT_DEVICE_KEYBOARD:
@@ -58,6 +58,7 @@ void wlr_input_device_destroy(struct wlr_input_device *dev) {
 	if (dev->impl && dev->impl->destroy) {
 		dev->impl->destroy(dev);
 	} else {
+		wl_list_remove(&dev->events.destroy.listener_list);
 		free(dev);
 	}
 }

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -14,6 +14,7 @@ void wlr_keyboard_destroy(struct wlr_keyboard *kb) {
 	if (kb && kb->impl && kb->impl->destroy) {
 		kb->impl->destroy(kb);
 	} else {
+		wl_list_remove(&kb->events.key.listener_list);
 		free(kb);
 	}
 }

--- a/types/wlr_pointer.c
+++ b/types/wlr_pointer.c
@@ -17,6 +17,10 @@ void wlr_pointer_destroy(struct wlr_pointer *pointer) {
 	if (pointer && pointer->impl && pointer->impl->destroy) {
 		pointer->impl->destroy(pointer);
 	} else {
+		wl_list_remove(&pointer->events.motion.listener_list);
+		wl_list_remove(&pointer->events.motion_absolute.listener_list);
+		wl_list_remove(&pointer->events.button.listener_list);
+		wl_list_remove(&pointer->events.axis.listener_list);
 		free(pointer);
 	}
 }


### PR DESCRIPTION
A few structs throughout the code use implementation specific free
functions.
When those functions are not used, they simply call free() on their
data, but this leaves around wl_signals linked into listeners.
When those listeners try to remove themself from the list, they write
into the now free memory.

This commit adds calls to remove the signals from those lists, so the
listeners can safely call wl_list_remove