### PR TITLE
xdg shell toplevel

### DIFF
--- a/examples/compositor.c
+++ b/examples/compositor.c
@@ -102,7 +102,7 @@ static void handle_output_frame(struct output_state *output,
 	struct wlr_xdg_surface_v6 *xdg_surface;
 	wl_list_for_each(xdg_surface, &sample->xdg_shell->surfaces, link) {
 		output_frame_handle_surface(sample, wlr_output, ts,
-			xdg_surface->surface);
+			xdg_surface->surface->resource);
 	}
 	struct wlr_x11_window *x11_window;
 	wl_list_for_each(x11_window, &sample->xwayland->displayable_windows, link) {

--- a/examples/compositor.c
+++ b/examples/compositor.c
@@ -64,6 +64,7 @@ struct example_xdg_surface_v6 {
 	struct wlr_xdg_surface_v6 *surface;
 
 	struct wl_listener destroy_listener;
+	struct wl_listener ping_timeout_listener;
 	struct wl_listener request_minimize_listener;
 	struct wl_listener request_move_listener;
 	struct wl_listener request_resize_listener;
@@ -98,11 +99,18 @@ static void output_frame_handle_surface(struct sample_state *sample,
 	}
 }
 
+static void handle_xdg_surface_v6_ping_timeout(struct wl_listener *listener,
+		void *data) {
+	struct wlr_xdg_surface_v6 *surface = data;
+	wlr_log(L_DEBUG, "got ping timeout for surface: %s", surface->title);
+}
+
 static void handle_xdg_surface_v6_destroy(struct wl_listener *listener,
 		void *data) {
 	struct example_xdg_surface_v6 *example_surface =
 		wl_container_of(listener, example_surface, destroy_listener);
 	wl_list_remove(&example_surface->destroy_listener.link);
+	wl_list_remove(&example_surface->ping_timeout_listener.link);
 	wl_list_remove(&example_surface->request_move_listener.link);
 	wl_list_remove(&example_surface->request_resize_listener.link);
 	wl_list_remove(&example_surface->request_show_window_menu_listener.link);
@@ -150,6 +158,8 @@ static void handle_new_xdg_surface_v6(struct wl_listener *listener,
 	wlr_log(L_DEBUG, "new xdg surface: title=%s, app_id=%s",
 		surface->title, surface->app_id);
 
+	wlr_xdg_surface_v6_ping(surface);
+
 	struct example_xdg_surface_v6 *esurface =
 		calloc(1, sizeof(struct example_xdg_surface_v6));
 	if (esurface == NULL) {
@@ -160,6 +170,10 @@ static void handle_new_xdg_surface_v6(struct wl_listener *listener,
 
 	wl_signal_add(&surface->events.destroy, &esurface->destroy_listener);
 	esurface->destroy_listener.notify = handle_xdg_surface_v6_destroy;
+
+	wl_signal_add(&surface->events.ping_timeout,
+		&esurface->ping_timeout_listener);
+	esurface->ping_timeout_listener.notify = handle_xdg_surface_v6_ping_timeout;
 
 	wl_signal_add(&surface->events.request_move,
 		&esurface->request_move_listener);
@@ -196,9 +210,12 @@ static void handle_output_frame(struct output_state *output,
 			wl_shell_surface->surface);
 	}
 	struct wlr_xdg_surface_v6 *xdg_surface;
-	wl_list_for_each(xdg_surface, &sample->xdg_shell->surfaces, link) {
-		output_frame_handle_surface(sample, wlr_output, ts,
-			xdg_surface->surface->resource);
+	struct wlr_xdg_client_v6 *xdg_client;
+	wl_list_for_each(xdg_client, &sample->xdg_shell->clients, link) {
+		wl_list_for_each(xdg_surface, &xdg_client->surfaces, link) {
+			output_frame_handle_surface(sample, wlr_output, ts,
+					xdg_surface->surface->resource);
+		}
 	}
 	struct wlr_x11_window *x11_window;
 	wl_list_for_each(x11_window, &sample->xwayland->displayable_windows, link) {

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -42,6 +42,7 @@ struct wlr_surface {
 
 	struct {
 		struct wl_signal commit;
+		struct wl_signal destroy;
 	} signals;
 
 	struct wl_list frame_callback_list; // wl_surface.frame

--- a/include/wlr/types/wlr_surface.h
+++ b/include/wlr/types/wlr_surface.h
@@ -70,4 +70,12 @@ void wlr_surface_get_matrix(struct wlr_surface *surface,
 		const float (*projection)[16],
 		const float (*transform)[16]);
 
+
+/**
+ * Set the lifetime role for this surface. Returns 0 on success or -1 if the
+ * role cannot be set.
+ */
+int wlr_surface_set_role(struct wlr_surface *surface, const char *role,
+		struct wl_resource *error_resource, uint32_t error_code);
+
 #endif

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -52,6 +52,12 @@ struct wlr_xdg_surface_v6 {
 	struct wl_listener surface_destroy_listener;
 	struct wl_listener surface_commit_listener;
 
+	struct {
+		struct wl_signal request_minimize;
+		struct wl_signal commit;
+		struct wl_signal destroy;
+	} events;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -22,6 +22,9 @@ struct wlr_xdg_surface_v6 {
 	struct wl_list link;
 	enum wlr_xdg_surface_v6_role role;
 
+	char *title;
+	char *app_id;
+
 	struct wl_listener surface_destroy_listener;
 	struct wl_listener surface_commit_listener;
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -63,7 +63,7 @@ struct wlr_xdg_toplevel_v6 {
 struct wlr_xdg_surface_v6_configure {
 	struct wl_list link; // wlr_xdg_surface_v6::configure_list
 	uint32_t serial;
-	struct wlr_xdg_toplevel_v6_state *state;
+	struct wlr_xdg_toplevel_v6_state state;
 };
 
 struct wlr_xdg_surface_v6 {

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -10,10 +10,17 @@ struct wlr_xdg_shell_v6 {
 	void *data;
 };
 
+enum wlr_xdg_surface_v6_role {
+	WLR_XDG_SURFACE_V6_ROLE_NONE,
+	WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL,
+	WLR_XDG_SURFACE_V6_ROLE_POPUP,
+};
+
 struct wlr_xdg_surface_v6 {
 	struct wl_resource *resource;
 	struct wl_resource *surface;
 	struct wl_list link;
+	enum wlr_xdg_surface_v6_role role;
 
 	struct wl_listener surface_destroy_listener;
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -15,6 +15,8 @@ struct wlr_xdg_surface_v6 {
 	struct wl_resource *surface;
 	struct wl_list link;
 
+	struct wl_listener surface_destroy_listener;
+
 	void *data;
 };
 

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -77,13 +77,41 @@ struct wlr_xdg_surface_v6 {
 	struct wl_listener surface_commit_listener;
 
 	struct {
-		struct wl_signal request_minimize;
 		struct wl_signal commit;
 		struct wl_signal destroy;
 		struct wl_signal ack_configure;
+
+		struct wl_signal request_minimize;
+		struct wl_signal request_move;
+		struct wl_signal request_resize;
+		struct wl_signal request_show_window_menu;
 	} events;
 
 	void *data;
+};
+
+struct wlr_xdg_toplevel_v6_move_event {
+	struct wl_client *client;
+	struct wlr_xdg_surface_v6 *surface;
+	struct wlr_seat_handle *seat_handle;
+	uint32_t serial;
+};
+
+struct wlr_xdg_toplevel_v6_resize_event {
+	struct wl_client *client;
+	struct wlr_xdg_surface_v6 *surface;
+	struct wlr_seat_handle *seat_handle;
+	uint32_t serial;
+	uint32_t edges;
+};
+
+struct wlr_xdg_toplevel_v6_show_window_menu_event {
+	struct wl_client *client;
+	struct wlr_xdg_surface_v6 *surface;
+	struct wlr_seat_handle *seat_handle;
+	uint32_t serial;
+	uint32_t x;
+	uint32_t y;
 };
 
 struct wlr_xdg_shell_v6 *wlr_xdg_shell_v6_create(struct wl_display *display);

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -17,11 +17,30 @@ enum wlr_xdg_surface_v6_role {
 	WLR_XDG_SURFACE_V6_ROLE_POPUP,
 };
 
+struct wlr_xdg_toplevel_v6_state {
+	bool maximized;
+	bool fullscreen;
+	bool resizing;
+	bool activated;
+
+	uint32_t max_width;
+	uint32_t max_height;
+
+	uint32_t min_width;
+	uint32_t min_height;
+};
+
+struct wlr_xdg_toplevel_v6 {
+	struct wlr_xdg_toplevel_v6_state next;
+	struct wlr_xdg_toplevel_v6_state current;
+};
+
 struct wlr_xdg_surface_v6 {
 	struct wl_resource *resource;
 	struct wlr_surface *surface;
 	struct wl_list link;
 	enum wlr_xdg_surface_v6_role role;
+	struct wlr_xdg_toplevel_v6 *toplevel_state;
 
 	char *title;
 	char *app_id;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -18,11 +18,12 @@ enum wlr_xdg_surface_v6_role {
 
 struct wlr_xdg_surface_v6 {
 	struct wl_resource *resource;
-	struct wl_resource *surface;
+	struct wlr_surface *surface;
 	struct wl_list link;
 	enum wlr_xdg_surface_v6_role role;
 
 	struct wl_listener surface_destroy_listener;
+	struct wl_listener surface_commit_listener;
 
 	void *data;
 };

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -1,5 +1,6 @@
 #ifndef _WLR_XDG_SHELL_V6_H
 #define _WLR_XDG_SHELL_V6_H
+#include <wlr/types/wlr_box.h>
 #include <wayland-server.h>
 
 struct wlr_xdg_shell_v6 {
@@ -24,6 +25,10 @@ struct wlr_xdg_surface_v6 {
 
 	char *title;
 	char *app_id;
+
+	bool has_next_geometry;
+	struct wlr_box *next_geometry;
+	struct wlr_box *geometry;
 
 	struct wl_listener surface_destroy_listener;
 	struct wl_listener surface_commit_listener;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -36,6 +36,7 @@ struct wlr_xdg_toplevel_v6_state {
 struct wlr_xdg_toplevel_v6 {
 	struct wl_resource *resource;
 	struct wlr_xdg_surface_v6 *base;
+	bool added;
 	struct wlr_xdg_toplevel_v6_state next; // client protocol requests
 	struct wlr_xdg_toplevel_v6_state pending; // user configure requests
 	struct wlr_xdg_toplevel_v6_state current;

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -53,6 +53,7 @@ struct wlr_xdg_toplevel_v6_state {
 struct wlr_xdg_toplevel_v6 {
 	struct wl_resource *resource;
 	struct wlr_xdg_surface_v6 *base;
+	struct wlr_xdg_surface_v6 *parent;
 	bool added;
 	struct wlr_xdg_toplevel_v6_state next; // client protocol requests
 	struct wlr_xdg_toplevel_v6_state pending; // user configure requests

--- a/include/wlr/types/wlr_xdg_shell_v6.h
+++ b/include/wlr/types/wlr_xdg_shell_v6.h
@@ -8,6 +8,10 @@ struct wlr_xdg_shell_v6 {
 	struct wl_list wl_resources;
 	struct wl_list surfaces;
 
+	struct {
+		struct wl_signal new_surface;
+	} events;
+
 	void *data;
 };
 
@@ -53,10 +57,12 @@ struct wlr_xdg_surface_v6 {
 	struct wl_client *client;
 	struct wl_resource *resource;
 	struct wlr_surface *surface;
+	struct wlr_xdg_shell_v6 *shell;
 	struct wl_list link;
 	enum wlr_xdg_surface_v6_role role;
 	struct wlr_xdg_toplevel_v6 *toplevel_state;
 
+	bool configured;
 	struct wl_event_source *configure_idle;
 	struct wl_list configure_list;
 
@@ -74,6 +80,7 @@ struct wlr_xdg_surface_v6 {
 		struct wl_signal request_minimize;
 		struct wl_signal commit;
 		struct wl_signal destroy;
+		struct wl_signal ack_configure;
 	} events;
 
 	void *data;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -422,3 +422,24 @@ void wlr_surface_get_matrix(struct wlr_surface *surface,
 	wlr_matrix_mul(matrix, &scale, matrix);
 	wlr_matrix_mul(projection, matrix, matrix);
 }
+
+int wlr_surface_set_role(struct wlr_surface *surface, const char *role,
+		struct wl_resource *error_resource, uint32_t error_code) {
+	assert(role);
+
+	if (surface->role == NULL ||
+			surface->role == role ||
+			strcmp(surface->role, role) == 0) {
+		surface->role = role;
+
+		return 0;
+	}
+
+	wl_resource_post_error(error_resource, error_code,
+		"Cannot assign role %s to wl_surface@%d, already has role %s\n",
+		role,
+		wl_resource_get_id(surface->resource),
+		surface->role);
+
+	return -1;
+}

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -365,6 +365,7 @@ const struct wl_surface_interface surface_interface = {
 
 static void destroy_surface(struct wl_resource *resource) {
 	struct wlr_surface *surface = wl_resource_get_user_data(resource);
+	wl_signal_emit(&surface->signals.destroy, surface);
 
 	wlr_texture_destroy(surface->texture);
 	struct wlr_frame_callback *cb, *next;
@@ -399,6 +400,7 @@ struct wlr_surface *wlr_surface_create(struct wl_resource *res,
 	pixman_region32_init(&surface->pending.opaque);
 	pixman_region32_init(&surface->pending.input);
 	wl_signal_init(&surface->signals.commit);
+	wl_signal_init(&surface->signals.destroy);
 	wl_list_init(&surface->frame_callback_list);
 	wl_resource_set_implementation(res, &surface_interface,
 		surface, destroy_surface);

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -21,7 +21,14 @@ static void resource_destroy(struct wl_client *client,
 
 static void xdg_toplevel_protocol_set_parent(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *parent_resource) {
-	wlr_log(L_DEBUG, "TODO: toplevel set parent");
+	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	struct wlr_xdg_surface_v6 *parent = NULL;
+
+	if (parent_resource != NULL) {
+		parent = wl_resource_get_user_data(parent_resource);
+	}
+
+	surface->toplevel_state->parent = parent;
 }
 
 static void xdg_toplevel_protocol_set_title(struct wl_client *client,

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -1,5 +1,9 @@
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_xdg_shell_v6.h>
 #include <wlr/types/wlr_surface.h>
@@ -21,12 +25,30 @@ static void xdg_toplevel_set_parent(struct wl_client *client,
 
 static void xdg_toplevel_set_title(struct wl_client *client,
 		struct wl_resource *resource, const char *title) {
-	wlr_log(L_DEBUG, "TODO: toplevel set title");
+	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	char *tmp;
+
+	tmp = strdup(title);
+	if (tmp == NULL) {
+		return;
+	}
+
+	free(surface->title);
+	surface->title = tmp;
 }
 
 static void xdg_toplevel_set_app_id(struct wl_client *client,
 		struct wl_resource *resource, const char *app_id) {
-	wlr_log(L_DEBUG, "TODO: toplevel set app id");
+	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+	char *tmp;
+
+	tmp = strdup(app_id);
+	if (tmp == NULL) {
+		return;
+	}
+
+	free(surface->app_id);
+	surface->app_id = tmp;
 }
 
 static void xdg_toplevel_show_window_menu(struct wl_client *client,
@@ -131,7 +153,7 @@ static void xdg_surface_get_toplevel(struct wl_client *client,
 		&zxdg_toplevel_v6_interface, wl_resource_get_version(resource), id);
 
 	wl_resource_set_implementation(toplevel_resource,
-		&zxdg_toplevel_v6_implementation, NULL, NULL);
+		&zxdg_toplevel_v6_implementation, surface, NULL);
 	struct wl_display *display = wl_client_get_display(client);
 	zxdg_surface_v6_send_configure(resource, wl_display_next_serial(display));
 }

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -5,7 +5,8 @@
 #include <wlr/util/log.h>
 #include "xdg-shell-unstable-v6-protocol.h"
 
-static void resource_destroy(struct wl_client *client, struct wl_resource *resource) {
+static void resource_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
 	// TODO: we probably need to do more than this
 	wl_resource_destroy(resource);
 }
@@ -58,23 +59,28 @@ static void xdg_toplevel_set_maximized(struct wl_client *client,
 	wlr_log(L_DEBUG, "TODO: toplevel set maximized");
 }
 
-static void xdg_toplevel_unset_maximized(struct wl_client *client, struct wl_resource *resource) {
+static void xdg_toplevel_unset_maximized(struct wl_client *client,
+		struct wl_resource *resource) {
 	wlr_log(L_DEBUG, "TODO: toplevel unset maximized");
 }
 
-static void xdg_toplevel_set_fullscreen(struct wl_client *client, struct wl_resource *resource, struct wl_resource *output_resource) {
+static void xdg_toplevel_set_fullscreen(struct wl_client *client,
+		struct wl_resource *resource, struct wl_resource *output_resource) {
 	wlr_log(L_DEBUG, "TODO: toplevel set fullscreen");
 }
 
-static void xdg_toplevel_unset_fullscreen(struct wl_client *client, struct wl_resource *resource) {
+static void xdg_toplevel_unset_fullscreen(struct wl_client *client,
+		struct wl_resource *resource) {
 	wlr_log(L_DEBUG, "TODO: toplevel unset fullscreen");
 }
 
-static void xdg_toplevel_set_minimized(struct wl_client *client, struct wl_resource *resource) {
+static void xdg_toplevel_set_minimized(struct wl_client *client,
+		struct wl_resource *resource) {
 	wlr_log(L_DEBUG, "TODO: toplevel set minimized");
 }
 
-static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation = {
+static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation =
+{
 	.destroy = resource_destroy,
 	.set_parent = xdg_toplevel_set_parent,
 	.set_title = xdg_toplevel_set_title,
@@ -118,7 +124,7 @@ static void xdg_surface_ack_configure(struct wl_client *client,
 		struct wl_resource *resource, uint32_t serial) {
 	wlr_log(L_DEBUG, "TODO xdg surface ack configure");
 }
- 
+
 static void xdg_surface_set_window_geometry(struct wl_client *client,
 		struct wl_resource *resource, int32_t x, int32_t y, int32_t width,
 		int32_t height) {
@@ -175,13 +181,15 @@ static void xdg_shell_bind(struct wl_client *wl_client, void *_xdg_shell,
 	struct wlr_xdg_shell_v6 *xdg_shell = _xdg_shell;
 	assert(wl_client && xdg_shell);
 	if (version > 1) {
-		wlr_log(L_ERROR, "Client requested unsupported xdg_shell_v6 version, disconnecting");
+		wlr_log(L_ERROR,
+			"Client requested unsupported xdg_shell_v6 version, disconnecting");
 		wl_client_destroy(wl_client);
 		return;
 	}
-	struct wl_resource *wl_resource = wl_resource_create(
-		wl_client, &zxdg_shell_v6_interface, version, id);
-	wl_resource_set_implementation(wl_resource, &xdg_shell_impl, xdg_shell, xdg_shell_destroy);
+	struct wl_resource *wl_resource =
+		wl_resource_create( wl_client, &zxdg_shell_v6_interface, version, id);
+	wl_resource_set_implementation(wl_resource, &xdg_shell_impl, xdg_shell,
+		xdg_shell_destroy);
 	wl_list_insert(&xdg_shell->wl_resources, wl_resource_get_link(wl_resource));
 }
 

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -632,14 +632,11 @@ static struct zxdg_shell_v6_interface xdg_shell_impl = {
 
 static void wlr_xdg_client_v6_destroy(struct wl_resource *resource) {
 	struct wlr_xdg_client_v6 *client = wl_resource_get_user_data(resource);
-	struct wl_list *list = &client->surfaces;
-	struct wl_list *link, *tmp;
 
-	for (link = list->next, tmp = link->next;
-			link != list;
-			link = tmp, tmp = link->next) {
-		wl_list_remove(link);
-		wl_list_init(link);
+	struct wlr_xdg_surface_v6 *surface, *tmp = NULL;
+	wl_list_for_each_safe(surface, tmp, &client->surfaces, link) {
+		wl_list_remove(&surface->link);
+		wl_list_init(&surface->link);
 	}
 
 	if (client->ping_timer != NULL) {

--- a/types/wlr_xdg_shell_v6.c
+++ b/types/wlr_xdg_shell_v6.c
@@ -18,12 +18,12 @@ static void resource_destroy(struct wl_client *client,
 	wl_resource_destroy(resource);
 }
 
-static void xdg_toplevel_set_parent(struct wl_client *client,
+static void xdg_toplevel_protocol_set_parent(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *parent_resource) {
 	wlr_log(L_DEBUG, "TODO: toplevel set parent");
 }
 
-static void xdg_toplevel_set_title(struct wl_client *client,
+static void xdg_toplevel_protocol_set_title(struct wl_client *client,
 		struct wl_resource *resource, const char *title) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	char *tmp;
@@ -37,7 +37,7 @@ static void xdg_toplevel_set_title(struct wl_client *client,
 	surface->title = tmp;
 }
 
-static void xdg_toplevel_set_app_id(struct wl_client *client,
+static void xdg_toplevel_protocol_set_app_id(struct wl_client *client,
 		struct wl_resource *resource, const char *app_id) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	char *tmp;
@@ -51,63 +51,63 @@ static void xdg_toplevel_set_app_id(struct wl_client *client,
 	surface->app_id = tmp;
 }
 
-static void xdg_toplevel_show_window_menu(struct wl_client *client,
+static void xdg_toplevel_protocol_show_window_menu(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *seat, uint32_t serial,
 		int32_t x, int32_t y) {
 	wlr_log(L_DEBUG, "TODO: toplevel show window menu");
 }
 
-static void xdg_toplevel_move(struct wl_client *client,
+static void xdg_toplevel_protocol_move(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *seat_resource,
 		uint32_t serial) {
 	wlr_log(L_DEBUG, "TODO: toplevel move");
 }
 
-static void xdg_toplevel_resize(struct wl_client *client,
+static void xdg_toplevel_protocol_resize(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *seat_resource,
 		uint32_t serial, uint32_t edges) {
 	wlr_log(L_DEBUG, "TODO: toplevel resize");
 }
 
-static void xdg_toplevel_set_max_size(struct wl_client *client,
+static void xdg_toplevel_protocol_set_max_size(struct wl_client *client,
 		struct wl_resource *resource, int32_t width, int32_t height) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	surface->toplevel_state->next.max_width = width;
 	surface->toplevel_state->next.max_height = height;
 }
 
-static void xdg_toplevel_set_min_size(struct wl_client *client,
+static void xdg_toplevel_protocol_set_min_size(struct wl_client *client,
 		struct wl_resource *resource, int32_t width, int32_t height) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	surface->toplevel_state->next.min_width = width;
 	surface->toplevel_state->next.min_height = height;
 }
 
-static void xdg_toplevel_set_maximized(struct wl_client *client,
+static void xdg_toplevel_protocol_set_maximized(struct wl_client *client,
 		struct wl_resource *resource) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	surface->toplevel_state->next.maximized = true;
 }
 
-static void xdg_toplevel_unset_maximized(struct wl_client *client,
+static void xdg_toplevel_protocol_unset_maximized(struct wl_client *client,
 		struct wl_resource *resource) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	surface->toplevel_state->next.maximized = false;
 }
 
-static void xdg_toplevel_set_fullscreen(struct wl_client *client,
+static void xdg_toplevel_protocol_set_fullscreen(struct wl_client *client,
 		struct wl_resource *resource, struct wl_resource *output_resource) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	surface->toplevel_state->next.fullscreen = true;
 }
 
-static void xdg_toplevel_unset_fullscreen(struct wl_client *client,
+static void xdg_toplevel_protocol_unset_fullscreen(struct wl_client *client,
 		struct wl_resource *resource) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	surface->toplevel_state->next.fullscreen = false;
 }
 
-static void xdg_toplevel_set_minimized(struct wl_client *client,
+static void xdg_toplevel_protocol_set_minimized(struct wl_client *client,
 		struct wl_resource *resource) {
 	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
 	wl_signal_emit(&surface->events.request_minimize, surface);
@@ -116,19 +116,19 @@ static void xdg_toplevel_set_minimized(struct wl_client *client,
 static const struct zxdg_toplevel_v6_interface zxdg_toplevel_v6_implementation =
 {
 	.destroy = resource_destroy,
-	.set_parent = xdg_toplevel_set_parent,
-	.set_title = xdg_toplevel_set_title,
-	.set_app_id = xdg_toplevel_set_app_id,
-	.show_window_menu = xdg_toplevel_show_window_menu,
-	.move = xdg_toplevel_move,
-	.resize = xdg_toplevel_resize,
-	.set_max_size = xdg_toplevel_set_max_size,
-	.set_min_size = xdg_toplevel_set_min_size,
-	.set_maximized = xdg_toplevel_set_maximized,
-	.unset_maximized = xdg_toplevel_unset_maximized,
-	.set_fullscreen = xdg_toplevel_set_fullscreen,
-	.unset_fullscreen = xdg_toplevel_unset_fullscreen,
-	.set_minimized = xdg_toplevel_set_minimized
+	.set_parent = xdg_toplevel_protocol_set_parent,
+	.set_title = xdg_toplevel_protocol_set_title,
+	.set_app_id = xdg_toplevel_protocol_set_app_id,
+	.show_window_menu = xdg_toplevel_protocol_show_window_menu,
+	.move = xdg_toplevel_protocol_move,
+	.resize = xdg_toplevel_protocol_resize,
+	.set_max_size = xdg_toplevel_protocol_set_max_size,
+	.set_min_size = xdg_toplevel_protocol_set_min_size,
+	.set_maximized = xdg_toplevel_protocol_set_maximized,
+	.unset_maximized = xdg_toplevel_protocol_unset_maximized,
+	.set_fullscreen = xdg_toplevel_protocol_set_fullscreen,
+	.unset_fullscreen = xdg_toplevel_protocol_unset_fullscreen,
+	.set_minimized = xdg_toplevel_protocol_set_minimized
 };
 
 static void xdg_surface_destroy(struct wlr_xdg_surface_v6 *surface) {
@@ -164,14 +164,15 @@ static void xdg_surface_get_toplevel(struct wl_client *client,
 	}
 
 	surface->role = WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL;
+	surface->toplevel_state->base = surface;
 
 	struct wl_resource *toplevel_resource = wl_resource_create(client,
 		&zxdg_toplevel_v6_interface, wl_resource_get_version(resource), id);
 
+	surface->toplevel_state->resource = toplevel_resource;
+
 	wl_resource_set_implementation(toplevel_resource,
 		&zxdg_toplevel_v6_implementation, surface, NULL);
-	struct wl_display *display = wl_client_get_display(client);
-	zxdg_surface_v6_send_configure(resource, wl_display_next_serial(display));
 }
 
 static void xdg_surface_get_popup(struct wl_client *client,
@@ -180,9 +181,64 @@ static void xdg_surface_get_popup(struct wl_client *client,
 	wlr_log(L_DEBUG, "TODO xdg surface get popup");
 }
 
+static void copy_toplevel_state(struct wlr_xdg_toplevel_v6_state *src,
+		struct wlr_xdg_toplevel_v6_state *dest) {
+	dest->width = src->width;
+	dest->height = src->height;
+	dest->max_width = src->max_width;
+	dest->max_height = src->max_height;
+	dest->min_width = src->min_width;
+	dest->min_height = src->min_height;
+
+	dest->fullscreen = src->fullscreen;
+	dest->resizing = src->resizing;
+	dest->activated = src->activated;
+	dest->maximized = src->maximized;
+}
+
+static void wlr_xdg_toplevel_v6_ack_configure(
+		struct wlr_xdg_surface_v6 *surface,
+		struct wlr_xdg_surface_v6_configure *configure) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	copy_toplevel_state(configure->state, &surface->toplevel_state->next);
+}
+
 static void xdg_surface_ack_configure(struct wl_client *client,
 		struct wl_resource *resource, uint32_t serial) {
 	wlr_log(L_DEBUG, "TODO xdg surface ack configure");
+	struct wlr_xdg_surface_v6 *surface = wl_resource_get_user_data(resource);
+
+	// TODO handle popups
+	if (surface->role != WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+		return;
+	}
+
+	bool found = false;
+	struct wlr_xdg_surface_v6_configure *configure, *tmp;
+	wl_list_for_each_safe(configure, tmp, &surface->configure_list, link) {
+		if (configure->serial < serial) {
+			wl_list_remove(&configure->link);
+			free(configure);
+		} else if (configure->serial == serial) {
+			wl_list_remove(&configure->link);
+			found = true;
+			break;
+		} else {
+			break;
+		}
+	}
+	if (!found) {
+		// TODO post error on the client resource
+		return;
+	}
+
+	// TODO handle popups
+	if (surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL) {
+		wlr_xdg_toplevel_v6_ack_configure(surface, configure);
+	}
+
+	// TODO send ack_configure event?
+	free(configure);
 }
 
 static void xdg_surface_set_window_geometry(struct wl_client *client,
@@ -218,29 +274,12 @@ static void handle_wlr_surface_destroyed(struct wl_listener *listener,
 
 static void wlr_xdg_surface_v6_toplevel_committed(
 		struct wlr_xdg_surface_v6 *surface) {
-	surface->toplevel_state->current.maximized =
-		surface->toplevel_state->next.maximized;
-	surface->toplevel_state->current.fullscreen =
-		surface->toplevel_state->next.fullscreen;
-	surface->toplevel_state->current.resizing =
-		surface->toplevel_state->next.resizing;
-	surface->toplevel_state->current.activated =
-		surface->toplevel_state->next.activated;
-
-	surface->toplevel_state->current.max_width =
-		surface->toplevel_state->next.max_width;
-	surface->toplevel_state->current.max_height =
-		surface->toplevel_state->next.max_height;
-
-	surface->toplevel_state->current.min_width =
-		surface->toplevel_state->next.min_width;
-	surface->toplevel_state->current.min_height =
-		surface->toplevel_state->next.min_height;
+	copy_toplevel_state(&surface->toplevel_state->next,
+		&surface->toplevel_state->current);
 }
 
 static void handle_wlr_surface_committed(struct wl_listener *listener,
 		void *data) {
-
 	struct wlr_xdg_surface_v6 *surface =
 		wl_container_of(listener, surface, surface_commit_listener);
 
@@ -279,10 +318,13 @@ static void xdg_shell_get_xdg_surface(struct wl_client *client,
 		return;
 	}
 
+	surface->client = client;
 	surface->role = WLR_XDG_SURFACE_V6_ROLE_NONE;
 	surface->surface = wl_resource_get_user_data(_surface);
 	surface->resource = wl_resource_create(client,
 		&zxdg_surface_v6_interface, wl_resource_get_version(_xdg_shell), id);
+
+	wl_list_init(&surface->configure_list);
 
 	wl_signal_init(&surface->events.request_minimize);
 	wl_signal_init(&surface->events.commit);
@@ -365,4 +407,162 @@ void wlr_xdg_shell_v6_destroy(struct wlr_xdg_shell_v6 *xdg_shell) {
 	// TODO: this segfault (wl_display->registry_resource_list is not init)
 	// wl_global_destroy(xdg_shell->wl_global);
 	free(xdg_shell);
+}
+
+static bool wlr_xdg_surface_v6_toplevel_state_compare(
+		struct wlr_xdg_toplevel_v6 *state) {
+	// is pending state different from current state?
+	if (state->pending.activated != state->current.activated) {
+		return false;
+	}
+	if (state->pending.fullscreen != state->current.fullscreen) {
+		return false;
+	}
+	if (state->pending.maximized != state->current.maximized) {
+		return false;
+	}
+	if (state->pending.resizing != state->current.resizing) {
+		return false;
+	}
+
+	if ((uint32_t)state->base->geometry->width == state->pending.width &&
+			(uint32_t)state->base->geometry->height == state->pending.height) {
+		return true;
+	}
+
+	if (state->pending.width == 0 && state->pending.height == 0) {
+		return true;
+	}
+
+	return false;
+}
+
+static void wlr_xdg_toplevel_v6_send_configure(
+		struct wlr_xdg_surface_v6 *surface,
+		struct wlr_xdg_surface_v6_configure *configure) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	uint32_t *s;
+	struct wl_array states;
+
+	configure->state = &surface->toplevel_state->pending;
+
+	wl_array_init(&states);
+	if (surface->toplevel_state->pending.maximized) {
+		s = wl_array_add(&states, sizeof(uint32_t));
+		*s = ZXDG_TOPLEVEL_V6_STATE_MAXIMIZED;
+	}
+	if (surface->toplevel_state->pending.fullscreen) {
+		s = wl_array_add(&states, sizeof(uint32_t));
+		*s = ZXDG_TOPLEVEL_V6_STATE_FULLSCREEN;
+	}
+	if (surface->toplevel_state->pending.resizing) {
+		s = wl_array_add(&states, sizeof(uint32_t));
+		*s = ZXDG_TOPLEVEL_V6_STATE_RESIZING;
+	}
+	if (surface->toplevel_state->pending.activated) {
+		s = wl_array_add(&states, sizeof(uint32_t));
+		*s = ZXDG_TOPLEVEL_V6_STATE_ACTIVATED;
+	}
+
+	zxdg_toplevel_v6_send_configure(surface->toplevel_state->resource,
+		surface->toplevel_state->pending.width,
+		surface->toplevel_state->pending.height,
+		&states);
+
+	wl_array_release(&states);
+}
+
+static void wlr_xdg_surface_send_configure(void *user_data) {
+	struct wlr_xdg_surface_v6 *surface = user_data;
+	struct wl_display *display = wl_client_get_display(surface->client);
+
+	// TODO handle popups
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+
+	surface->configure_idle = NULL;
+
+	// TODO handle no memory
+	struct wlr_xdg_surface_v6_configure *configure =
+		calloc(1, sizeof(struct wlr_xdg_surface_v6_configure));
+	wl_list_insert(surface->configure_list.prev, &configure->link);
+	configure->serial = wl_display_next_serial(display);
+
+	wlr_xdg_toplevel_v6_send_configure(surface, configure);
+
+	zxdg_surface_v6_send_configure(surface->resource, configure->serial);
+}
+
+static void wlr_xdg_surface_v6_schedule_configure(
+		struct wlr_xdg_surface_v6 *surface) {
+	// TODO handle popups
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+
+	struct wl_display *display = wl_client_get_display(surface->client);
+	struct wl_event_loop *loop = wl_display_get_event_loop(display);
+
+	bool pending_same =
+		wlr_xdg_surface_v6_toplevel_state_compare(surface->toplevel_state);
+
+	if (surface->configure_idle != NULL) {
+		if (!pending_same) {
+			// configure request already scheduled
+			return;
+		}
+
+		// configure request not necessary anymore
+		wl_event_source_remove(surface->configure_idle);
+		surface->configure_idle = NULL;
+	} else {
+		if (pending_same) {
+			// configure request not necessary
+			return;
+		}
+
+		surface->configure_idle =
+			wl_event_loop_add_idle(
+				loop,
+				wlr_xdg_surface_send_configure,
+				surface);
+	}
+}
+
+void wlr_xdg_toplevel_v6_set_size(struct wlr_xdg_surface_v6 *surface,
+		uint32_t width, uint32_t height) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	surface->toplevel_state->pending.width = width;
+	surface->toplevel_state->pending.height = height;
+
+	wlr_xdg_surface_v6_schedule_configure(surface);
+}
+
+void wlr_xdg_toplevel_v6_set_activated(struct wlr_xdg_surface_v6 *surface,
+		bool activated) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	surface->toplevel_state->pending.activated = activated;
+
+	wlr_xdg_surface_v6_schedule_configure(surface);
+}
+
+void wlr_xdg_toplevel_v6_set_maximized(struct wlr_xdg_surface_v6 *surface,
+		bool maximized) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	surface->toplevel_state->pending.maximized = maximized;
+
+	wlr_xdg_surface_v6_schedule_configure(surface);
+}
+
+void wlr_xdg_toplevel_v6_set_fullscreen(struct wlr_xdg_surface_v6 *surface,
+		bool fullscreen) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	surface->toplevel_state->pending.fullscreen = fullscreen;
+
+	wlr_xdg_surface_v6_schedule_configure(surface);
+}
+
+void wlr_xdg_toplevel_v6_set_resizing(struct wlr_xdg_surface_v6 *surface,
+		bool resizing) {
+	assert(surface->role == WLR_XDG_SURFACE_V6_ROLE_TOPLEVEL);
+	surface->toplevel_state->pending.fullscreen = resizing;
+
+	wlr_xdg_surface_v6_schedule_configure(surface);
 }


### PR DESCRIPTION
In this PR I want to flesh out the xdg shell toplevel.

We can use this as a basis to decide the abstractions for the other shells and what interface is provided to the user.

Our shell implementation will consist simply of a desktop surface state that is changed by the client through the protocol and convenience functions for common things like configure requests. Library users can choose to interpret these values how they want.

Open questions:
* How are users notified of desktop surface state changes?
* Is there enough similarity between the shells (title, geometry, etc.) to make them a subclass of a `wlr_desktop_surface` to make them easier to work with?