### PR TITLE
Install files with meson

### DIFF
--- a/dist/archlinux/PKGBUILD
+++ b/dist/archlinux/PKGBUILD
@@ -1,0 +1,48 @@
+pkgname=wlroots
+pkgver=r600.d89272d
+pkgrel=1
+license=('MIT')
+pkgdesc='Wayland compositor library'
+makedepends=("meson")
+depends=(
+	"wayland"
+	"wayland-protocols"
+	"mesa"
+	"libdrm"
+	"libinput"
+	"libxkbcommon"
+	"libsystemd"
+	"pixman"
+	"libxcb"
+)
+arch=("x86_64")
+url="https://github.com/SirCmpwn/wlroots"
+source=("${pkgname}::git+https://github.com/SirCmpwn/wlroots.git")
+sha1sums=('SKIP')
+provides=('wlroots')
+conflicts=('wlroots')
+
+pkgver() {
+	cd "${srcdir}/${pkgname}"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+	cd "${srcdir}/${pkgname}"
+
+	meson build \
+		--prefix=/usr \
+		-Dbuildtype=debugoptimized \
+		-Db_lto=True \
+		-Denable-systemd=True \
+		-Denable-elogind=False \
+		-Denable-libcap=False
+
+	ninja -C build
+}
+
+package() {
+	cd "${srcdir}/${pkgname}"
+
+	DESTDIR="${pkgdir}" ninja -C build install
+}

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ add_project_link_arguments(
 )
 
 wlr_inc = include_directories('include')
+install_subdir('include/wlr', install_dir: 'include')
 
 cc = meson.get_compiler('c')
 
@@ -103,6 +104,7 @@ lib_wlr = library(
 	],
 	dependencies: wlr_deps,
 	include_directories: wlr_inc,
+	install: true,
 )
 
 wlroots = declare_dependency(
@@ -112,3 +114,12 @@ wlroots = declare_dependency(
 )
 
 subdir('examples')
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(
+	libraries: lib_wlr,
+	version: '0.0.1',
+	filebase: 'wlroots',
+	name: 'wlroots',
+	description: 'Wayland compositor library',
+)


### PR DESCRIPTION
Actually install libwlroots.so and include/wlr, as well as generate a pkg-config file.
I'm not 100% sure I generated the pkg-config file correctly, but I can seem to link wlroots using it.

I also added an Archlinux PKGBUILD, because it'll be useful (at least for me) for when sway is going to be ported. I don't really expect this to live in here forever, but it's still too early to put this on the AUR.