### PR TITLE
fix libinput wlr-keyboard use after free

### DIFF
--- a/backend/libinput/keyboard.c
+++ b/backend/libinput/keyboard.c
@@ -21,7 +21,6 @@ static void wlr_libinput_keyboard_destroy(struct wlr_keyboard *wlr_kb) {
 	struct wlr_libinput_keyboard *wlr_libinput_kb =
 		(struct wlr_libinput_keyboard *)wlr_kb;
 	libinput_device_unref(wlr_libinput_kb->libinput_dev);
-	free(wlr_libinput_kb);
 }
 
 struct wlr_keyboard_impl impl = {

--- a/types/wlr_keyboard.c
+++ b/types/wlr_keyboard.c
@@ -41,9 +41,9 @@ void wlr_keyboard_destroy(struct wlr_keyboard *kb) {
 		kb->impl->destroy(kb);
 	} else {
 		wl_list_remove(&kb->events.key.listener_list);
-		free(kb);
 	}
 	close(kb->keymap_fd);
+	free(kb);
 }
 
 void wlr_keyboard_led_update(struct wlr_keyboard *kb, uint32_t leds) {


### PR DESCRIPTION
Fixes use after free error when switching VTs and keyboard gets destroyed and recreated.