### PR TITLE
rootston: create desktop before input

### DIFF
--- a/rootston/desktop.c
+++ b/rootston/desktop.c
@@ -78,11 +78,6 @@ struct roots_desktop *desktop_create(struct roots_server *server,
 	desktop->compositor = wlr_compositor_create(
 			server->wl_display, server->renderer);
 
-	wlr_cursor_attach_output_layout(server->input->cursor, desktop->layout);
-	wlr_cursor_map_to_region(server->input->cursor, config->cursor.mapped_box);
-	cursor_load_config(config, server->input->cursor,
-			server->input, desktop);
-
 	desktop->xdg_shell_v6 = wlr_xdg_shell_v6_create(server->wl_display);
 	wl_signal_add(&desktop->xdg_shell_v6->events.new_surface,
 		&desktop->xdg_shell_v6_surface);

--- a/rootston/input.c
+++ b/rootston/input.c
@@ -71,6 +71,8 @@ static void input_remove_notify(struct wl_listener *listener, void *data) {
 struct roots_input *input_create(struct roots_server *server,
 		struct roots_config *config) {
 	wlr_log(L_DEBUG, "Initializing roots input");
+	assert(server->desktop);
+
 	struct roots_input *input = calloc(1, sizeof(struct roots_input));
 	assert(input);
 
@@ -103,6 +105,11 @@ struct roots_input *input_create(struct roots_server *server,
 	input->cursor = wlr_cursor_create();
 	cursor_initialize(input);
 	wlr_cursor_set_xcursor(input->cursor, input->xcursor);
+
+	wlr_cursor_attach_output_layout(input->cursor, server->desktop->layout);
+	wlr_cursor_map_to_region(input->cursor, config->cursor.mapped_box);
+	cursor_load_config(config, input->cursor,
+		input, server->desktop);
 
 	return input;
 }

--- a/rootston/main.c
+++ b/rootston/main.c
@@ -20,8 +20,8 @@ int main(int argc, char **argv) {
 
 	assert(server.renderer = wlr_gles2_renderer_create(server.backend));
 	wl_display_init_shm(server.wl_display);
-	server.input = input_create(&server, server.config);
 	server.desktop = desktop_create(&server, server.config);
+	server.input = input_create(&server, server.config);
 	server.data_device_manager = wlr_data_device_manager_create(
 			server.wl_display);
 


### PR DESCRIPTION
This is a workaround for a weston toy toolkit bug which expects the compositor global to be listed before the seat global. Without this change, `weston-terminal` and all other toy toolkit apps will not work. This is because their seat initialization depends on the compositor (to create a pointer surface). So if the seat is listed first, their initialization fails because there is no compositor yet. 

