### PR TITLE
rootston: add view->resize for xwayland

### DIFF
--- a/include/wlr/xwayland.h
+++ b/include/wlr/xwayland.h
@@ -81,7 +81,8 @@ struct wlr_xwayland *wlr_xwayland_create(struct wl_display *wl_display,
 void wlr_xwayland_surface_activate(struct wlr_xwayland *wlr_xwayland,
 	struct wlr_xwayland_surface *surface);
 void wlr_xwayland_surface_configure(struct wlr_xwayland *wlr_xwayland,
-	struct wlr_xwayland_surface *surface);
+	struct wlr_xwayland_surface *surface, int16_t x, int16_t y,
+	uint16_t width, uint16_t height);
 void wlr_xwayland_surface_close(struct wlr_xwayland *wlr_xwayland,
 	struct wlr_xwayland_surface *surface);
 

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -9,6 +9,14 @@
 #include "rootston/desktop.h"
 #include "rootston/server.h"
 
+static void resize(struct roots_view *view, uint32_t width, uint32_t height) {
+	assert(view->type == ROOTS_XWAYLAND_VIEW);
+	struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
+	xwayland_surface->width = width;
+	xwayland_surface->height = height;
+	wlr_xwayland_surface_configure(view->desktop->xwayland, xwayland_surface);
+}
+
 static void handle_destroy(struct wl_listener *listener, void *data) {
 	struct roots_xwayland_surface *roots_surface =
 		wl_container_of(listener, roots_surface, destroy);
@@ -75,6 +83,7 @@ void handle_xwayland_surface(struct wl_listener *listener, void *data) {
 	view->wlr_surface = surface->surface;
 	view->desktop = desktop;
 	view->activate = activate;
+	view->resize = resize;
 	roots_surface->view = view;
 	list_add(desktop->views, view);
 }

--- a/rootston/xwayland.c
+++ b/rootston/xwayland.c
@@ -12,9 +12,8 @@
 static void resize(struct roots_view *view, uint32_t width, uint32_t height) {
 	assert(view->type == ROOTS_XWAYLAND_VIEW);
 	struct wlr_xwayland_surface *xwayland_surface = view->xwayland_surface;
-	xwayland_surface->width = width;
-	xwayland_surface->height = height;
-	wlr_xwayland_surface_configure(view->desktop->xwayland, xwayland_surface);
+	wlr_xwayland_surface_configure(view->desktop->xwayland, xwayland_surface,
+		xwayland_surface->x, xwayland_surface->y, width, height);
 }
 
 static void handle_destroy(struct wl_listener *listener, void *data) {
@@ -32,16 +31,11 @@ static void handle_request_configure(struct wl_listener *listener, void *data) {
 		roots_surface->view->xwayland_surface;
 	struct wlr_xwayland_surface_configure_event *event = data;
 
-	xwayland_surface->x = event->x;
-	xwayland_surface->y = event->y;
-	xwayland_surface->width = event->width;
-	xwayland_surface->height = event->height;
-
 	roots_surface->view->x = (double)event->x;
 	roots_surface->view->y = (double)event->y;
 
 	wlr_xwayland_surface_configure(roots_surface->view->desktop->xwayland,
-		xwayland_surface);
+		xwayland_surface, event->x, event->y, event->width, event->height);
 }
 
 static void activate(struct roots_view *view, bool active) {

--- a/xwayland/xwm.c
+++ b/xwayland/xwm.c
@@ -355,11 +355,8 @@ static void handle_configure_request(struct wlr_xwm *xwm,
 
 	if (surface->surface == NULL) {
 		// Surface has not been mapped yet
-		surface->x = ev->x;
-		surface->y = ev->y;
-		surface->width = ev->width;
-		surface->height = ev->height;
-		wlr_xwayland_surface_configure(xwm->xwayland, surface);
+		wlr_xwayland_surface_configure(xwm->xwayland, surface, ev->x, ev->y,
+			ev->width, ev->height);
 	} else {
 		struct wlr_xwayland_surface_configure_event *wlr_event =
 			calloc(1, sizeof(struct wlr_xwayland_surface_configure_event));
@@ -610,13 +607,18 @@ void wlr_xwayland_surface_activate(struct wlr_xwayland *wlr_xwayland,
 }
 
 void wlr_xwayland_surface_configure(struct wlr_xwayland *wlr_xwayland,
-		struct wlr_xwayland_surface *surface) {
+		struct wlr_xwayland_surface *surface, int16_t x, int16_t y,
+		uint16_t width, uint16_t height) {
+	surface->x = x;
+	surface->y = y;
+	surface->width = width;
+	surface->height = height;
+
 	struct wlr_xwm *xwm = wlr_xwayland->xwm;
 	uint32_t mask = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y |
 		XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT |
 		XCB_CONFIG_WINDOW_BORDER_WIDTH;
-	uint32_t values[] = {surface->x, surface->y, surface->width,
-		surface->height, 0};
+	uint32_t values[] = {x, y, width, height, 0};
 	xcb_configure_window(xwm->xcb_conn, surface->window_id, mask, values);
 }
 


### PR DESCRIPTION
Client requests for resize/move are already processed by `handle_request_configure`. I tested that with this program: https://gist.github.com/emersion/cc4909ba3581928871192822fc96d00b

It's the compositor's responsibility to detect mouse clicks near window borders and resize windows, if the compositor wants to have this feature. This is different from xdg shell (since xdg shell clients draw their own decorations).

This adds `view->resize` that will be used to force resize with meta+rclick.